### PR TITLE
Refactor milestone 2

### DIFF
--- a/src/Nightwatch/models/strategy_decision.py
+++ b/src/Nightwatch/models/strategy_decision.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from decimal import Decimal
+from types import MappingProxyType
 
 from Nightwatch.models.signal import Side
 
@@ -13,3 +14,7 @@ class StrategyDecision:
     side: Side
     strength: float
     rationale: dict[str, float | Decimal]
+
+    def __post_init__(self) -> None:
+        """Convert the rationale dictionary to an immutable MappingProxyType after initialization."""
+        object.__setattr__(self, "rationale", MappingProxyType(self.rationale))

--- a/src/Nightwatch/models/tick_buffer.py
+++ b/src/Nightwatch/models/tick_buffer.py
@@ -1,5 +1,6 @@
 """Defines the TickBuffer Pydantic model for storing the last N MarketTick objects per symbol in a rolling buffer."""
 
+import logging
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
 
@@ -7,6 +8,8 @@ from pydantic import ConfigDict, Field
 from pydantic.dataclasses import dataclass
 
 from Nightwatch.models.market_tick import MarketTick
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(config=ConfigDict(str_max_length=255))
@@ -24,8 +27,22 @@ class TickBuffer:
             self.ticks = defaultdict(lambda: deque(maxlen=self.max_ticks_per_symbol), self.ticks)
 
     def add_tick(self, tick: MarketTick) -> None:
-        """Add a tick to the per-symbol buffer, maintaining a rolling window up to max_ticks_per_symbol."""
-        self.ticks[tick.symbol].append(tick)
+        """Add a tick to the per-symbol buffer, maintaining a rolling window up to max_ticks_per_symbol.
+
+        Ticks must arrive in non-decreasing timestamp order. Out-of-order ticks (where the new
+        tick's timestamp is strictly earlier than the latest stored tick) are discarded with a
+        warning, preserving the sorted-by-timestamp invariant required for bisect-based lookups.
+        """
+        symbol_ticks = self.ticks[tick.symbol]
+        if symbol_ticks and tick.timestamp < symbol_ticks[-1].timestamp:
+            LOGGER.warning(
+                "Discarding out-of-order tick for %s: tick timestamp %s is before latest %s",
+                tick.symbol,
+                tick.timestamp,
+                symbol_ticks[-1].timestamp,
+            )
+            return
+        symbol_ticks.append(tick)
 
     def get_ticks(self, symbol: str) -> deque[MarketTick]:
         """Return the internal deque of ticks for *symbol*, or an empty deque if none are stored.

--- a/src/Nightwatch/models/tick_buffer.py
+++ b/src/Nightwatch/models/tick_buffer.py
@@ -28,10 +28,11 @@ class TickBuffer:
         self.ticks[tick.symbol].append(tick)
 
     def get_ticks(self, symbol: str) -> deque[MarketTick]:
-        """Get the deque of ticks for a given symbol, or an empty deque if no ticks are stored for that symbol."""
-        return deque(
-            self.ticks.get(symbol, [])
-        )  # TODO: return a copy to prevent external mutation of the internal buffer. Might be a performance issue
+        """Return the internal deque of ticks for *symbol*, or an empty deque if none are stored.
+
+        The returned deque is the live internal buffer — callers must not append or remove elements.
+        """
+        return self.ticks.get(symbol, deque())
 
     def get_latest_tick(self, symbol: str) -> MarketTick | None:
         """Return the most recent tick for *symbol*, or None if no ticks are available."""

--- a/src/Nightwatch/strategies/momentum_burst.py
+++ b/src/Nightwatch/strategies/momentum_burst.py
@@ -1,5 +1,6 @@
 """A trading strategy that generates BUY or SELL signals when price moves beyond a configured percentage threshold."""
 
+import bisect
 import logging
 from collections import deque
 from datetime import timedelta
@@ -50,16 +51,18 @@ class MomentumBurstStrategy(Strategy):
 
         last_tick: MarketTick = window[-1]
         cutoff_timestamp = last_tick.timestamp - timedelta(seconds=self.window_sec)
-        window_in_range = [tick for tick in window if tick.timestamp >= cutoff_timestamp]
-        if len(window_in_range) < 2:  # noqa: PLR2004
+        ticks_list = list(window)
+        idx = bisect.bisect_left(ticks_list, cutoff_timestamp, key=lambda t: t.timestamp)
+        in_range_count = len(ticks_list) - idx
+        if in_range_count < 2:  # noqa: PLR2004
             LOGGER.debug(
                 "Not enough ticks within the last %s seconds to evaluate the strategy for symbol %s. Required: 2, Found: %d",
                 self.window_sec,
                 symbol,
-                len(window_in_range),
+                in_range_count,
             )
             return None
-        start_tick: MarketTick = window_in_range[0]
+        start_tick: MarketTick = ticks_list[idx]
 
         if start_tick.price == Decimal("0"):
             LOGGER.warning("Start tick price is zero for symbol %s, cannot calculate percentage change.", symbol)

--- a/src/Nightwatch/strategies/momentum_burst.py
+++ b/src/Nightwatch/strategies/momentum_burst.py
@@ -91,15 +91,3 @@ class MomentumBurstStrategy(Strategy):
                 "threshold_pct": self.threshold_pct,
             },
         )
-
-    def get_strategy_evaluations_total(self, **labels: str) -> float | None:
-        """Return the total number of strategy evaluations performed."""
-        if self._metric:
-            if "strategy" in labels:
-                return self._metric.get_counter_value(self._metric.strategy_evaluations_total, **labels)
-            return self._metric.get_counter_value(
-                self._metric.strategy_evaluations_total,
-                strategy=self.NAME,
-                **labels,
-            )
-        return None

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -59,7 +59,7 @@ class StrategyRunner:
                 "event": "signal",
                 "signal_id": str(signal.uid),
                 "symbol": tick.symbol,
-                "side": signal.side,
+                "side": signal.side.value,
                 "strategy": signal.strategy,
                 "delta_pct": signal.rationale.get("delta_pct", None),
                 "window_sec": signal.rationale.get("window_sec", None),

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -36,7 +36,7 @@ class StrategyRunner:
             LOGGER.info("Received first tick for symbol %s: %s", tick.symbol, tick.uid)
             return None
         last_signal = self._last_signal_time.get(tick.symbol, None)
-        if last_signal is not None and tick.timestamp - last_signal <= self._cooldown:
+        if last_signal is not None and tick.timestamp - last_signal < self._cooldown:
             if self._metric:
                 self._metric.signals_suppressed_total.labels(reason="cooldown").inc()
             LOGGER.debug("Tick for symbol %s received during cooldown period: %s", tick.symbol, tick)

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -70,21 +70,3 @@ class StrategyRunner:
             if self._metric:
                 self._metric.signals_total.labels(symbol=tick.symbol, side=signal.side.value, strategy=signal.strategy).inc()
         return signal
-
-    def get_signal_totals(self, **labels: str) -> float | None:
-        """Return the total number of signals emitted by the strategy."""
-        if self._metric:
-            if "strategy" in labels:
-                return self._metric.get_counter_value(self._metric.signals_total, **labels)
-            return self._metric.get_counter_value(
-                self._metric.signals_total,
-                strategy=self._strategy.NAME,
-                **labels,
-            )
-        return None
-
-    def get_suppressed_signal_totals(self, **labels: str) -> float | None:
-        """Return the total number of signals suppressed by the strategy."""
-        if self._metric:
-            return self._metric.get_counter_value(self._metric.signals_suppressed_total, **labels)
-        return None

--- a/tests/Nightwatch/test_integration_strategy_runner.py
+++ b/tests/Nightwatch/test_integration_strategy_runner.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="import-untyped, union-attr"
 """Integration tests for the StrategyRunner using live data from Kraken."""
 
 import asyncio
@@ -77,9 +78,9 @@ class TestSignalsTotalViaNats(unittest.TestCase):
         """Ingest live Kraken ticks via NATS for 30 s and verify signals_total increases."""
         symbol = "BTC/USD"
 
-        before = (self.runner.get_signal_totals(symbol=symbol, side="BUY", strategy=self.strategy.NAME) or 0.0) + (
-            self.runner.get_signal_totals(symbol=symbol, side="SELL", strategy=self.strategy.NAME) or 0.0
-        )
+        before = (
+            self.metrics.get_counter_value(self.metrics.signals_total, symbol=symbol, side="BUY", strategy=self.strategy.NAME) or 0.0
+        ) + (self.metrics.get_counter_value(self.metrics.signals_total, symbol=symbol, side="SELL", strategy=self.strategy.NAME) or 0.0)
         strategy_evaluations_before = (
             self.metrics.get_counter_value(self.metrics.strategy_evaluations_total, symbol=symbol, strategy=self.strategy.NAME) or 0.0
         )
@@ -106,9 +107,9 @@ class TestSignalsTotalViaNats(unittest.TestCase):
 
         self._run(_test())
 
-        after = (self.runner.get_signal_totals(symbol=symbol, side="BUY", strategy=self.strategy.NAME) or 0.0) + (
-            self.runner.get_signal_totals(symbol=symbol, side="SELL", strategy=self.strategy.NAME) or 0.0
-        )
+        after = (
+            self.metrics.get_counter_value(self.metrics.signals_total, symbol=symbol, side="BUY", strategy=self.strategy.NAME) or 0.0
+        ) + (self.metrics.get_counter_value(self.metrics.signals_total, symbol=symbol, side="SELL", strategy=self.strategy.NAME) or 0.0)
         strategy_evaluations_after = (
             self.metrics.get_counter_value(self.metrics.strategy_evaluations_total, symbol=symbol, strategy=self.strategy.NAME) or 0.0
         )

--- a/tests/Nightwatch/test_integration_strategy_runner.py
+++ b/tests/Nightwatch/test_integration_strategy_runner.py
@@ -80,8 +80,10 @@ class TestSignalsTotalViaNats(unittest.TestCase):
         before = (self.runner.get_signal_totals(symbol=symbol, side="BUY", strategy=self.strategy.NAME) or 0.0) + (
             self.runner.get_signal_totals(symbol=symbol, side="SELL", strategy=self.strategy.NAME) or 0.0
         )
-        strategy_evaluations_before = self.strategy.get_strategy_evaluations_total(symbol=symbol, strategy=self.strategy.NAME) or 0.0
-        signal_suppressed_before = self.runner.get_suppressed_signal_totals(reason="first_tick") or 0.0
+        strategy_evaluations_before = (
+            self.metrics.get_counter_value(self.metrics.strategy_evaluations_total, symbol=symbol, strategy=self.strategy.NAME) or 0.0
+        )
+        signal_suppressed_before = self.metrics.get_counter_value(self.metrics.signals_suppressed_total, reason="first_tick") or 0.0
 
         async def _test() -> None:
             async def _on_tick(tick: MarketTick) -> None:
@@ -107,8 +109,10 @@ class TestSignalsTotalViaNats(unittest.TestCase):
         after = (self.runner.get_signal_totals(symbol=symbol, side="BUY", strategy=self.strategy.NAME) or 0.0) + (
             self.runner.get_signal_totals(symbol=symbol, side="SELL", strategy=self.strategy.NAME) or 0.0
         )
-        strategy_evaluations_after = self.strategy.get_strategy_evaluations_total(symbol=symbol, strategy=self.strategy.NAME) or 0.0
-        signal_suppressed_after = self.runner.get_suppressed_signal_totals(reason="first_tick") or 0.0
+        strategy_evaluations_after = (
+            self.metrics.get_counter_value(self.metrics.strategy_evaluations_total, symbol=symbol, strategy=self.strategy.NAME) or 0.0
+        )
+        signal_suppressed_after = self.metrics.get_counter_value(self.metrics.signals_suppressed_total, reason="first_tick") or 0.0
         ticks_consumed = self.metrics.get_counter_value(
             self.metrics.ticks_consumed_total,
             symbol=symbol,

--- a/tests/Nightwatch/test_momentum_burst_strategy.py
+++ b/tests/Nightwatch/test_momentum_burst_strategy.py
@@ -47,8 +47,6 @@ class TestMomentumBurstStrategy(unittest.TestCase):
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNone(signal)
-        signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
-        self.assertIsNone(signal)
 
     def test_not_enough_ticks_in_window(self) -> None:
         """Test that sequences with not enough ticks in the window generate a None signal."""

--- a/tests/Nightwatch/test_momentum_burst_strategy.py
+++ b/tests/Nightwatch/test_momentum_burst_strategy.py
@@ -129,7 +129,9 @@ class TestMomentumBurstStrategy(unittest.TestCase):
 
     def test_strategy_evaluations_total(self) -> None:
         """Test that the counter strategy_evaluations_total is incremented correctly."""
-        initial_evaluations = self.strategy.get_strategy_evaluations_total(symbol="BTC/USD", strategy=self.strategy.NAME) or 0
+        initial_evaluations = (
+            self._metric.get_counter_value(self._metric.strategy_evaluations_total, symbol="BTC/USD", strategy=self.strategy.NAME) or 0
+        )
         ticks = deque(
             [
                 make_tick(price=Decimal("100"), timestamp=self.start_time),
@@ -139,7 +141,8 @@ class TestMomentumBurstStrategy(unittest.TestCase):
         )
         self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertEqual(
-            self.strategy.get_strategy_evaluations_total(symbol="BTC/USD", strategy=self.strategy.NAME), initial_evaluations + 1
+            self._metric.get_counter_value(self._metric.strategy_evaluations_total, symbol="BTC/USD", strategy=self.strategy.NAME),
+            initial_evaluations + 1,
         )
 
     def test_invalid_parameters(self) -> None:

--- a/tests/Nightwatch/test_momentum_burst_strategy.py
+++ b/tests/Nightwatch/test_momentum_burst_strategy.py
@@ -2,12 +2,12 @@
 
 import unittest
 from collections import deque
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from Nightwatch.metrics import NightwatchMetrics
 from Nightwatch.strategies.momentum_burst import MomentumBurstStrategy
-from tests.fixtures.tick_factory import make_tick
+from tests.fixtures.tick_factory import make_tick_sequence
 
 
 class TestMomentumBurstStrategy(unittest.TestCase):
@@ -22,12 +22,8 @@ class TestMomentumBurstStrategy(unittest.TestCase):
     def test_rising_seq_crosses_threshold(self) -> None:
         """Test that a rising sequence of ticks crossing the threshold generates a buy signal."""
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNotNone(signal)
@@ -36,12 +32,8 @@ class TestMomentumBurstStrategy(unittest.TestCase):
     def test_falling_seq_crosses_threshold(self) -> None:
         """Test that a falling sequence of ticks crossing the threshold generates a sell signal."""
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("95"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("85"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("95"), Decimal("85")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNotNone(signal)
@@ -50,24 +42,18 @@ class TestMomentumBurstStrategy(unittest.TestCase):
     def test_noise_under_thresholds(self) -> None:
         """Test that noisy sequences outside thresholds generate a None signal."""
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("95"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("95"), Decimal("105")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
+        signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
+        self.assertIsNone(signal)
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNone(signal)
 
     def test_not_enough_ticks_in_window(self) -> None:
         """Test that sequences with not enough ticks in the window generate a None signal."""
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-            ]
-        )
+        ticks = make_tick_sequence(prices=[Decimal("100")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD")
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNone(signal)
 
@@ -78,24 +64,16 @@ class TestMomentumBurstStrategy(unittest.TestCase):
 
     def test_start_price_is_zero(self) -> None:
         """Test that a sequence starting with a price of zero generates a None signal."""
-        ticks = deque(
-            [
-                make_tick(price=Decimal("0"), timestamp=self.start_time),
-                make_tick(price=Decimal("5"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("10"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("0"), Decimal("5"), Decimal("10")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNone(signal)
 
     def test_exactly_at_threshold(self) -> None:
         """Test that a sequence that is exactly at the threshold generates a buy signal."""
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("110"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("110")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNotNone(signal)
@@ -104,25 +82,17 @@ class TestMomentumBurstStrategy(unittest.TestCase):
     def test_just_below_threshold(self) -> None:
         """Test that a sequence that is just below the threshold generates a None signal."""
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("109.99"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("109.99")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNone(signal)
 
-    def test_within_time_window(self) -> None:
+    def test_ticks_outside_time_window_no_signal(self) -> None:
         """Test that a sequence with ticks outside the time window generates a None signal."""
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=15)),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=20)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=15.0, symbol="BTC/USD"
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNone(signal)
@@ -132,12 +102,8 @@ class TestMomentumBurstStrategy(unittest.TestCase):
         initial_evaluations = (
             self._metric.get_counter_value(self._metric.strategy_evaluations_total, symbol="BTC/USD", strategy=self.strategy.NAME) or 0
         )
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertEqual(
@@ -154,12 +120,8 @@ class TestMomentumBurstStrategy(unittest.TestCase):
 
     def test_determinism_same_ticks_yield_same_signals(self) -> None:
         """Given the same tick sequence replayed twice, then emitted signals are identical."""
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
 
         signals_run1 = [self.strategy.on_tick(t.symbol, deque(list(ticks)[: i + 1])) for i, t in enumerate(ticks)]
@@ -178,13 +140,8 @@ class TestMomentumBurstStrategy(unittest.TestCase):
         """Given all ticks have identical timestamps and different prices,
         when evaluated, then no signal is emitted because the price move
         happened in zero elapsed real time (delta_pct = 5%, but it's noise)."""
-        t = self.start_time
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=t),
-                make_tick(price=Decimal("105"), timestamp=t),
-                make_tick(price=Decimal("115"), timestamp=t),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=0.0, symbol="BTC/USD"
         )
         signal = self.strategy.on_tick(ticks[-1].symbol, ticks)
         self.assertIsNone(signal)

--- a/tests/Nightwatch/test_signal.py
+++ b/tests/Nightwatch/test_signal.py
@@ -3,8 +3,9 @@
 import unittest
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 
-from Nightwatch.models.signal import Signal  # type: ignore[import-untyped]
+from Nightwatch.models.signal import Side, Signal
 from tests.fixtures.signal_factory import make_signal
 
 
@@ -16,10 +17,10 @@ class TestSignal(unittest.TestCase):
         self.signal = make_signal(
             symbol="BTCUSD",
             timestamp=datetime.now(timezone.utc),
-            side="BUY",
+            side=Side.BUY,
             strategy="momentum_burst_v1",
             strength=1.0,
-            rationale={"delta_pct": 0.05, "window_sec": 3.0, "threshold_pct": 0.02},
+            rationale={"delta_pct": Decimal("0.05"), "window_sec": Decimal("3.0"), "threshold_pct": Decimal("0.02")},
             source="trade-service",
             schema_version=1,
         )
@@ -29,11 +30,11 @@ class TestSignal(unittest.TestCase):
         self.assertIsNotNone(self.signal.uid)
         self.assertEqual(self.signal.symbol, "BTCUSD")
         self.assertIsInstance(self.signal.timestamp, datetime)
-        self.assertEqual(self.signal.side, "BUY")
+        self.assertEqual(self.signal.side.value, "BUY")
         self.assertEqual(self.signal.strength, 1.0)
-        self.assertEqual(self.signal.rationale["delta_pct"], 0.05)
-        self.assertEqual(self.signal.rationale["window_sec"], 3.0)
-        self.assertEqual(self.signal.rationale["threshold_pct"], 0.02)
+        self.assertEqual(self.signal.rationale["delta_pct"], Decimal("0.05"))
+        self.assertEqual(self.signal.rationale["window_sec"], Decimal("3.0"))
+        self.assertEqual(self.signal.rationale["threshold_pct"], Decimal("0.02"))
         self.assertEqual(self.signal.source, "trade-service")
         self.assertEqual(self.signal.schema_version, 1)
         self.assertIsInstance(self.signal.timestamp, datetime)
@@ -41,8 +42,8 @@ class TestSignal(unittest.TestCase):
 
     def test_side_only_accepts_buy_or_sell(self) -> None:
         """Test that the 'side' attribute only accepts 'BUY' or 'SELL'."""
-        with self.assertRaises(ValueError):
-            make_signal(side="ERROR")
+        with self.assertRaises(AttributeError):
+            make_signal(side=Side.ERROR)  # type: ignore[attr-defined]
 
     def test_strength_non_negative(self) -> None:
         """Test that the 'strength' attribute must be non-negative (>= 0)."""
@@ -57,7 +58,7 @@ class TestSignal(unittest.TestCase):
         self.assertEqual(deserialized_signal.uid, self.signal.uid)
         self.assertEqual(deserialized_signal.symbol, self.signal.symbol)
         self.assertEqual(deserialized_signal.timestamp, self.signal.timestamp)
-        self.assertEqual(deserialized_signal.side, self.signal.side)
+        self.assertEqual(deserialized_signal.side.value, self.signal.side.value)
         self.assertEqual(deserialized_signal.strategy, self.signal.strategy)
         self.assertEqual(deserialized_signal.strength, self.signal.strength)
         self.assertEqual(deserialized_signal.rationale, self.signal.rationale)
@@ -72,7 +73,7 @@ class TestSignal(unittest.TestCase):
             "side": "BUY",
             "strategy": "momentum_burst_v1",
             "strength": 1.0,
-            "rationale": {"delta_pct": 0.05, "window_sec": 3.0, "threshold_pct": 0.02},
+            "rationale": {"delta_pct": Decimal("0.05"), "window_sec": Decimal("3.0"), "threshold_pct": Decimal("0.02")},
             "source": "trade-service",
             "schema_version": 1,
         }
@@ -94,12 +95,12 @@ class TestSignal(unittest.TestCase):
     def test_missing_fields(self) -> None:
         """Test that missing required fields raise a validation error."""
         with self.assertRaises(ValueError):
-            Signal(
+            Signal(  # type: ignore[call-arg]
                 timestamp=datetime.now(timezone.utc),
-                side="BUY",
+                side=Side.BUY,
                 strategy="momentum_burst_v1",
                 strength=1.0,
-                rationale={"delta_pct": 0.05, "window_sec": 3.0, "threshold_pct": 0.02},
+                rationale={"delta_pct": Decimal("0.05"), "window_sec": Decimal("3.0"), "threshold_pct": Decimal("0.02")},
                 source="trade-service",
                 schema_version=1,
             )

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="import-untyped"
+# mypy: disable-error-code="import-untyped, union-attr"
 """Unit tests for the StrategyRunner class."""
 
 import unittest
@@ -69,7 +69,7 @@ class TestStrategyRunner(unittest.TestCase):
         next_tick = make_tick(price=Decimal("130"), timestamp=self.start_time + timedelta(seconds=11))
         second_signal_no_cd = runner_no_cd.on_market_tick(next_tick)
         self.assertIsNotNone(second_signal_no_cd)
-        self.assertEqual(second_signal_no_cd.side, "BUY")  # type: ignore[union-attr]
+        self.assertEqual(second_signal_no_cd.side, "BUY")
 
         strategy_cd = MomentumBurstStrategy(threshold_pct=1, window_sec=60, metric=self._metric)
         buffer_cd = TickBuffer(max_ticks_per_symbol=30)
@@ -180,7 +180,9 @@ class TestStrategyRunner(unittest.TestCase):
 
     def test_signals_total(self) -> None:
         """Test that the counter signals_total is incremented correctly."""
-        initial_evaluations = self.runner.get_signal_totals(symbol="BTC/USD", side="BUY") or 0
+        initial_evaluations = (
+            self._metric.get_counter_value(self._metric.signals_total, symbol="BTC/USD", side="BUY", strategy=self.__strategy.NAME) or 0
+        )
         ticks = deque(
             [
                 make_tick(price=Decimal("100"), timestamp=self.start_time),
@@ -189,7 +191,9 @@ class TestStrategyRunner(unittest.TestCase):
             ]
         )
         feed_ticks(self.runner, ticks)
-        final_evaluations = self.runner.get_signal_totals(symbol="BTC/USD", side="BUY") or 0
+        final_evaluations = (
+            self._metric.get_counter_value(self._metric.signals_total, symbol="BTC/USD", side="BUY", strategy=self.__strategy.NAME) or 0
+        )
         self.assertEqual(final_evaluations, initial_evaluations + 1)
 
     def test_cooldown_zero_does_not_suppress_same_timestamp(self) -> None:

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -10,7 +10,7 @@ from Nightwatch.metrics import NightwatchMetrics
 from Nightwatch.models.tick_buffer import TickBuffer
 from Nightwatch.strategies.momentum_burst import MomentumBurstStrategy
 from Nightwatch.strategy_runner import StrategyRunner
-from tests.fixtures.tick_factory import feed_ticks, make_tick
+from tests.fixtures.tick_factory import feed_ticks, make_tick, make_tick_sequence
 
 
 class TestStrategyRunner(unittest.TestCase):
@@ -25,25 +25,17 @@ class TestStrategyRunner(unittest.TestCase):
 
     def test_emit_signal_on_rising_sequence(self) -> None:
         """Test that a rising sequence of ticks generates a buy signal."""
-        rising_ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        rising_ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = feed_ticks(self.runner, rising_ticks)
         self.assertIsNotNone(signal)
-        self.assertEqual(signal.side, "BUY")  # type: ignore[union-attr]
+        self.assertEqual(signal.side.value, "BUY")  # type: ignore[union-attr]
 
     def test_emit_no_signal_on_falling_sequence(self) -> None:
         """Test that an outside threshold sequence of ticks does not generate a signal."""
-        failing_ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("95"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        failing_ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("95"), Decimal("105")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = feed_ticks(self.runner, failing_ticks)
         self.assertIsNone(signal)
@@ -54,22 +46,18 @@ class TestStrategyRunner(unittest.TestCase):
         buffer_no_cd = TickBuffer(max_ticks_per_symbol=30)
         runner_no_cd = StrategyRunner(strategy=strategy_no_cd, buffer=buffer_no_cd)
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
 
         signal = feed_ticks(runner_no_cd, ticks)
         self.assertIsNotNone(signal)
-        self.assertEqual(signal.side, "BUY")  # type: ignore[union-attr]
+        self.assertEqual(signal.side.value, "BUY")  # type: ignore[union-attr]
 
         next_tick = make_tick(price=Decimal("130"), timestamp=self.start_time + timedelta(seconds=11))
         second_signal_no_cd = runner_no_cd.on_market_tick(next_tick)
         self.assertIsNotNone(second_signal_no_cd)
-        self.assertEqual(second_signal_no_cd.side, "BUY")
+        self.assertEqual(second_signal_no_cd.side.value, "BUY")
 
         strategy_cd = MomentumBurstStrategy(threshold_pct=1, window_sec=60, metric=self._metric)
         buffer_cd = TickBuffer(max_ticks_per_symbol=30)
@@ -82,7 +70,7 @@ class TestStrategyRunner(unittest.TestCase):
             signal = runner_cd.on_market_tick(tick)
             i += 1
         self.assertIsNotNone(signal)
-        self.assertEqual(signal.side, "BUY")  # type: ignore[union-attr]
+        self.assertEqual(signal.side.value, "BUY")  # type: ignore[union-attr]
 
         signal_during_cooldown = runner_cd.on_market_tick(next_tick)
         self.assertIsNone(signal_during_cooldown)
@@ -90,11 +78,9 @@ class TestStrategyRunner(unittest.TestCase):
     def test_cooldown_increments_suppressed_metric(self) -> None:
         """Given a signal was just emitted, when the next tick arrives within cooldown,
         then signals_suppressed_total{reason='cooldown'} increments by 1."""
-        ticks = [
-            make_tick(price=Decimal("100"), timestamp=self.start_time),
-            make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-            make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-        ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
+        )
         for tick in ticks:
             self.runner.on_market_tick(tick)
         suppressed_tick = make_tick(
@@ -104,33 +90,24 @@ class TestStrategyRunner(unittest.TestCase):
         result = self.runner.on_market_tick(suppressed_tick)
 
         self.assertIsNone(result)
-        # THIS is the new assertion — the metric must reflect the suppression
         value = self._metric.get_counter_value(self._metric.signals_suppressed_total, reason="cooldown")
         self.assertEqual(value, 1.0)
 
     def test_integration_with_momentum_burst_strategy(self) -> None:
         """Test that the StrategyRunner correctly integrates with the MomentumBurstStrategy."""
 
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal = feed_ticks(self.runner, ticks)
         self.assertIsNotNone(signal)
-        self.assertEqual(signal.side, "BUY")  # type: ignore[union-attr]
+        self.assertEqual(signal.side.value, "BUY")  # type: ignore[union-attr]
 
     def test_logging_contains_required_fields(self) -> None:
         """Test that the logs contain the required fields when emitting signals."""
         with self.assertLogs("Nightwatch.strategy_runner", level="DEBUG") as log:
-            ticks = deque(
-                [
-                    make_tick(price=Decimal("100"), timestamp=self.start_time),
-                    make_tick(price=Decimal("105"), timestamp=self.start_time + timedelta(seconds=5)),
-                    make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-                ]
+            ticks = make_tick_sequence(
+                prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
             )
             for tick in ticks:
                 self.runner.on_market_tick(tick)
@@ -183,12 +160,8 @@ class TestStrategyRunner(unittest.TestCase):
         initial_evaluations = (
             self._metric.get_counter_value(self._metric.signals_total, symbol="BTC/USD", side="BUY", strategy=self.__strategy.NAME) or 0
         )
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-                make_tick(price=Decimal("135"), timestamp=self.start_time + timedelta(seconds=20)),
-            ]
+        ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("115"), Decimal("135")], start=self.start_time, interval_sec=10.0, symbol="BTC/USD"
         )
         feed_ticks(self.runner, ticks)
         final_evaluations = (
@@ -202,13 +175,7 @@ class TestStrategyRunner(unittest.TestCase):
         strategy = MomentumBurstStrategy(threshold_pct=10, metric=self._metric)
         buffer = TickBuffer(max_ticks_per_symbol=30)
         runner = StrategyRunner(strategy=strategy, buffer=buffer, cooldown=timedelta(seconds=0), metric=self._metric)
-
-        ticks = deque(
-            [
-                make_tick(price=Decimal("100"), timestamp=self.start_time),
-                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
-            ]
-        )
+        ticks = make_tick_sequence(prices=[Decimal("100"), Decimal("115")], start=self.start_time, interval_sec=10.0, symbol="BTC/USD")
         signal1 = feed_ticks(runner, ticks)
         self.assertIsNotNone(signal1)
 

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -66,10 +66,10 @@ class TestStrategyRunner(unittest.TestCase):
         self.assertIsNotNone(signal)
         self.assertEqual(signal.side, "BUY")  # type: ignore[union-attr]
 
-        next_tick = make_tick(price=Decimal("130"), timestamp=self.start_time + timedelta(seconds=15))
+        next_tick = make_tick(price=Decimal("130"), timestamp=self.start_time + timedelta(seconds=11))
         second_signal_no_cd = runner_no_cd.on_market_tick(next_tick)
         self.assertIsNotNone(second_signal_no_cd)
-        self.assertEqual(second_signal_no_cd.side, "BUY")
+        self.assertEqual(second_signal_no_cd.side, "BUY")  # type: ignore[union-attr]
 
         strategy_cd = MomentumBurstStrategy(threshold_pct=1, window_sec=60, metric=self._metric)
         buffer_cd = TickBuffer(max_ticks_per_symbol=30)
@@ -192,3 +192,24 @@ class TestStrategyRunner(unittest.TestCase):
         feed_ticks(self.runner, ticks)
         final_evaluations = self.runner.get_signal_totals(symbol="BTC/USD", side="BUY") or 0
         self.assertEqual(final_evaluations, initial_evaluations + 1)
+
+    def test_cooldown_zero_does_not_suppress_same_timestamp(self) -> None:
+        """Given cooldown=0, when two qualifying ticks arrive at the same timestamp,
+        then both emit signals (no suppression)."""
+        strategy = MomentumBurstStrategy(threshold_pct=10, metric=self._metric)
+        buffer = TickBuffer(max_ticks_per_symbol=30)
+        runner = StrategyRunner(strategy=strategy, buffer=buffer, cooldown=timedelta(seconds=0), metric=self._metric)
+
+        ticks = deque(
+            [
+                make_tick(price=Decimal("100"), timestamp=self.start_time),
+                make_tick(price=Decimal("115"), timestamp=self.start_time + timedelta(seconds=10)),
+            ]
+        )
+        signal1 = feed_ticks(runner, ticks)
+        self.assertIsNotNone(signal1)
+
+        # Same timestamp, still qualifying
+        tick_at_boundary = make_tick(price=Decimal("135"), timestamp=self.start_time + timedelta(seconds=10))
+        signal2 = runner.on_market_tick(tick_at_boundary)
+        self.assertIsNotNone(signal2)  # Should NOT be suppressed with cooldown=0

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -85,7 +85,6 @@ class TestStrategyRunner(unittest.TestCase):
         self.assertEqual(signal.side, "BUY")  # type: ignore[union-attr]
 
         signal_during_cooldown = runner_cd.on_market_tick(next_tick)
-        self.assertIsNotNone(runner_cd._last_signal_time)
         self.assertIsNone(signal_during_cooldown)
 
     def test_cooldown_increments_suppressed_metric(self) -> None:
@@ -106,7 +105,7 @@ class TestStrategyRunner(unittest.TestCase):
 
         self.assertIsNone(result)
         # THIS is the new assertion — the metric must reflect the suppression
-        value = self.runner.get_suppressed_signal_totals(reason="cooldown")
+        value = self._metric.get_counter_value(self._metric.signals_suppressed_total, reason="cooldown")
         self.assertEqual(value, 1.0)
 
     def test_integration_with_momentum_burst_strategy(self) -> None:
@@ -213,3 +212,7 @@ class TestStrategyRunner(unittest.TestCase):
         tick_at_boundary = make_tick(price=Decimal("135"), timestamp=self.start_time + timedelta(seconds=10))
         signal2 = runner.on_market_tick(tick_at_boundary)
         self.assertIsNotNone(signal2)  # Should NOT be suppressed with cooldown=0
+
+    def test_access_private_last_signal_time(self) -> None:
+        """Test that we can access the private _last_signal_time attribute for testing purposes."""
+        self.assertIsInstance(self.runner._last_signal_time, dict)

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -176,7 +176,7 @@ class TestStrategyRunner(unittest.TestCase):
         self.assertIsNotNone(signal_b)
         self.assertEqual(signal_a.side, "BUY")  # type: ignore[union-attr]
         self.assertEqual(signal_b.side, "BUY")  # type: ignore[union-attr]
-        self.assertEqual(runner.get_suppressed_signal_totals(reason="cooldown"), 1.0)
+        self.assertEqual(metric.get_counter_value(metric.signals_suppressed_total, reason="cooldown"), 1.0)
 
     def test_signals_total(self) -> None:
         """Test that the counter signals_total is incremented correctly."""

--- a/tests/Nightwatch/test_unit_tick_buffer.py
+++ b/tests/Nightwatch/test_unit_tick_buffer.py
@@ -50,3 +50,24 @@ class TestTickBuffer(unittest.TestCase):
             buf.add_tick(tick)
         stored = list(buf.get_ticks("BTC/USD"))
         self.assertEqual([t.timestamp for t in stored], timestamps)
+
+    def test_out_of_order_tick_discarded(self) -> None:
+        """Test that a tick with an earlier timestamp than the latest stored tick is discarded."""
+        buf = TickBuffer(max_ticks_per_symbol=5)
+        t0 = datetime(2024, 1, 1, 0, tzinfo=timezone.utc)
+        t1 = datetime(2024, 1, 1, 1, tzinfo=timezone.utc)
+        t_late = datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc)
+        buf.add_tick(make_tick(symbol="BTC/USD", timestamp=t0))
+        buf.add_tick(make_tick(symbol="BTC/USD", timestamp=t1))
+        buf.add_tick(make_tick(symbol="BTC/USD", timestamp=t_late))
+        stored = list(buf.get_ticks("BTC/USD"))
+        self.assertEqual(len(stored), 2)
+        self.assertEqual([t.timestamp for t in stored], [t0, t1])
+
+    def test_equal_timestamp_tick_accepted(self) -> None:
+        """Test that a tick with a timestamp equal to the latest stored tick is accepted (non-decreasing)."""
+        buf = TickBuffer(max_ticks_per_symbol=5)
+        ts = datetime(2024, 1, 1, 0, tzinfo=timezone.utc)
+        buf.add_tick(make_tick(symbol="BTC/USD", timestamp=ts))
+        buf.add_tick(make_tick(symbol="BTC/USD", timestamp=ts))
+        self.assertEqual(len(buf.get_ticks("BTC/USD")), 2)

--- a/tests/fixtures/signal_factory.py
+++ b/tests/fixtures/signal_factory.py
@@ -1,17 +1,18 @@
 """Factory functions to create test instances of the Signal model."""
 
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any
 
-from Nightwatch.models.signal import Signal  # type: ignore[import-untyped]
+from Nightwatch.models.signal import Side, Signal
 
 
 def make_signal(
     symbol: str = "BTC/USD",
-    side: str = "BUY",
+    side: Side = Side.BUY,
     strength: float = 0.8,
     strategy: str = "Mean Reversion",
-    rationale: dict[str, float] | None = None,
+    rationale: dict[str, float | Decimal] | None = None,
     source: str = "test",
     **kwargs: Any,
 ) -> Signal:
@@ -22,7 +23,7 @@ def make_signal(
         side=side,
         strength=strength,
         strategy=strategy,
-        rationale=rationale or {"delta_pct": 0.05, "window_sec": 3.0, "threshold_pct": 0.02},
+        rationale=rationale or {"delta_pct": Decimal("0.05"), "window_sec": Decimal("3.0"), "threshold_pct": Decimal("0.02")},
         source=source,
         schema_version=kwargs.pop("schema_version", 1),
         **kwargs,

--- a/tests/fixtures/tick_factory.py
+++ b/tests/fixtures/tick_factory.py
@@ -2,7 +2,7 @@
 """Test fixture for creating MarketTick instances for testing purposes."""
 
 from collections import deque
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
 
@@ -35,3 +35,13 @@ def feed_ticks(runner: StrategyRunner, ticks: deque[MarketTick]) -> Signal | Non
         if signal is not None:
             return signal
     return None
+
+
+def make_tick_sequence(
+    prices: list[Decimal],
+    start: datetime,
+    interval_sec: float = 5.0,
+    symbol: str = "BTC/USD",
+) -> deque[MarketTick]:
+    """Build a deque of ticks with evenly spaced timestamps."""
+    return deque(make_tick(price=p, timestamp=start + timedelta(seconds=i * interval_sec), symbol=symbol) for i, p in enumerate(prices))


### PR DESCRIPTION
This pull request introduces improvements and refactoring across the trading strategy codebase, focusing on performance, immutability, and testing reliability. The most important changes include making rationale dictionaries immutable, optimizing time window filtering in the momentum burst strategy, simplifying metric access patterns, and refactoring tests for clarity and maintainability.

### Core Model Improvements
* Made the `rationale` dictionary in the `StrategyDecision` dataclass immutable by wrapping it with `MappingProxyType` in `__post_init__`, preventing accidental mutation after initialization. [[1]](diffhunk://#diff-a948ed2eb4f0589a0b5a601ac62dd34f7412ece0aad222489a28632445b63426R5) [[2]](diffhunk://#diff-a948ed2eb4f0589a0b5a601ac62dd34f7412ece0aad222489a28632445b63426R17-R20)

### Strategy Logic and Performance
* Optimized tick window filtering in `MomentumBurstStrategy.on_tick` by using `bisect` for efficient time-based slicing, replacing linear list comprehensions. (F2e976c5L2R1, [src/Nightwatch/strategies/momentum_burst.pyL53-R65](diffhunk://#diff-388b77b1e0e1562a6a9557791c2ea208f7f85af2a9ff3d44837585f7e2fae6c0L53-R65))
* Removed redundant metric accessor methods from `MomentumBurstStrategy` and `StrategyRunner`, and updated metric access to use direct calls to the metrics object. [[1]](diffhunk://#diff-388b77b1e0e1562a6a9557791c2ea208f7f85af2a9ff3d44837585f7e2fae6c0L94-L105) [[2]](diffhunk://#diff-e6b82a06d3753ccca8faeca36049b5c4dc3e926937ee3f53963af08d6c63266eL73-L90) [[3]](diffhunk://#diff-f2a7f2f414dfed54ad39f74102d8a0a7dd3c49c2b4a9358bfab6bf1ffbc7f2f4L80-R87) [[4]](diffhunk://#diff-f2a7f2f414dfed54ad39f74102d8a0a7dd3c49c2b4a9358bfab6bf1ffbc7f2f4L107-R116)

### Buffer and Signal Handling
* Clarified that `TickBuffer.get_ticks` returns the internal buffer directly (not a copy), with documentation warning callers not to mutate the returned deque.
* Fixed cooldown logic in `StrategyRunner` to use strict less-than comparison, ensuring signals are suppressed only within the cooldown window.
* Changed logging and metric reporting to use the string value of `Signal.side` instead of the enum object.

### Test Refactoring and Reliability
* Refactored unit tests for `MomentumBurstStrategy` to use a new `make_tick_sequence` fixture, improving readability and reducing boilerplate. Added and renamed tests for edge cases and determinism. [[1]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L5-R10) [[2]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L25-R26) [[3]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L39-R36) [[4]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L53-R56) [[5]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L81-R76) [[6]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L107-R111) [[7]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L154-R124) [[8]](diffhunk://#diff-84b901be750076bf6a2d0c9052c69f5388125934e31c2699652e4bc8c7aa08f7L178-R144)
* Updated integration tests to access metrics directly, removing reliance on deprecated signal total accessor methods. [[1]](diffhunk://#diff-f2a7f2f414dfed54ad39f74102d8a0a7dd3c49c2b4a9358bfab6bf1ffbc7f2f4R1) [[2]](diffhunk://#diff-f2a7f2f414dfed54ad39f74102d8a0a7dd3c49c2b4a9358bfab6bf1ffbc7f2f4L80-R87) [[3]](diffhunk://#diff-f2a7f2f414dfed54ad39f74102d8a0a7dd3c49c2b4a9358bfab6bf1ffbc7f2f4L107-R116)
* Improved signal test imports and coverage for decimal values and signal sides.