### PR TITLE
feat: implement BotControlEvent model

### DIFF
--- a/src/Nightwatch/models/bot_control_event.py
+++ b/src/Nightwatch/models/bot_control_event.py
@@ -1,0 +1,32 @@
+"""Model to represent a bot control event, such as killing a bot for a specific reason at a certain timestamp."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class BotControlEvent(BaseModel):
+    """Model to represent a bot control event."""
+
+    kill: bool
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    reason: str = Field(min_length=1)
+
+    model_config = ConfigDict(str_max_length=255)
+
+    @field_validator("kill", mode="before")
+    @classmethod
+    def kill_must_be_bool(cls, v: Any | None) -> bool | None:
+        """Ensure that kill is strictly a bool (not int, str, etc)."""
+        if not isinstance(v, bool):
+            raise ValueError("kill must be a boolean (True or False), not %r" % type(v).__name__)
+        return v
+
+    @field_validator("reason")
+    @classmethod
+    def reason_not_blank(cls, v: str) -> str:
+        """Ensure that the reason is not blank or just whitespace."""
+        if not v.strip():
+            raise ValueError("reason must not be blank")
+        return v

--- a/src/Nightwatch/models/bot_control_event.py
+++ b/src/Nightwatch/models/bot_control_event.py
@@ -1,6 +1,6 @@
 """Model to represent a bot control event, such as killing a bot for a specific reason at a certain timestamp."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -10,14 +10,14 @@ class BotControlEvent(BaseModel):
     """Model to represent a bot control event."""
 
     kill: bool
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime
     reason: str = Field(min_length=1)
 
     model_config = ConfigDict(str_max_length=255)
 
     @field_validator("kill", mode="before")
     @classmethod
-    def kill_must_be_bool(cls, v: Any | None) -> bool | None:
+    def kill_must_be_bool(cls, v: Any) -> bool:
         """Ensure that kill is strictly a bool (not int, str, etc)."""
         if not isinstance(v, bool):
             raise ValueError("kill must be a boolean (True or False), not %r" % type(v).__name__)

--- a/tests/Nightwatch/test_bot_control_event.py
+++ b/tests/Nightwatch/test_bot_control_event.py
@@ -1,0 +1,50 @@
+"""Unit tests for the BotControlEvent model."""
+
+import unittest
+from datetime import datetime
+
+from Nightwatch.models.bot_control_event import BotControlEvent
+
+
+class TestBotControlEvent(unittest.TestCase):
+    """Unit tests for the BotControlEvent model."""
+
+    def test_valid_bot_control_event(self) -> None:
+        """Test that a valid BotControlEvent can be created."""
+        event = BotControlEvent(
+            kill=True,
+            timestamp=datetime.now(),
+            reason="Testing bot control event",
+        )
+        self.assertTrue(event.kill)
+        self.assertIsInstance(event.timestamp, datetime)
+        self.assertEqual(event.reason, "Testing bot control event")
+
+    def test_reason_cannot_be_blank(self) -> None:
+        """Test that the reason field cannot be blank or just whitespace."""
+        with self.assertRaises(ValueError):
+            BotControlEvent(
+                kill=True,
+                reason="   ",  # Just whitespace
+            )
+
+    def test_json_roundtrip(self) -> None:
+        """Test that a BotControlEvent can be serialized to JSON and deserialized back."""
+        event = BotControlEvent(
+            kill=False,
+            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+            reason="Scheduled maintenance",
+        )
+        json_data = event.model_dump_json()
+        deserialized_event = BotControlEvent.model_validate_json(json_data)
+        self.assertEqual(event.kill, deserialized_event.kill)
+        self.assertEqual(event.timestamp, deserialized_event.timestamp)
+        self.assertEqual(event.reason, deserialized_event.reason)
+
+    def test_kill_is_boolean(self) -> None:
+        """Test that the kill field must be a boolean."""
+        with self.assertRaises(ValueError):
+            BotControlEvent(
+                kill="yes",  # type: ignore[arg-type]
+                reason="Invalid kill value",
+            )

--- a/tests/Nightwatch/test_bot_control_event.py
+++ b/tests/Nightwatch/test_bot_control_event.py
@@ -1,7 +1,7 @@
 """Unit tests for the BotControlEvent model."""
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from Nightwatch.models.bot_control_event import BotControlEvent
 
@@ -13,7 +13,7 @@ class TestBotControlEvent(unittest.TestCase):
         """Test that a valid BotControlEvent can be created."""
         event = BotControlEvent(
             kill=True,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(timezone.utc),
             reason="Testing bot control event",
         )
         self.assertTrue(event.kill)
@@ -25,6 +25,7 @@ class TestBotControlEvent(unittest.TestCase):
         with self.assertRaises(ValueError):
             BotControlEvent(
                 kill=True,
+                timestamp=datetime.now(timezone.utc),
                 reason="   ",  # Just whitespace
             )
 
@@ -32,7 +33,7 @@ class TestBotControlEvent(unittest.TestCase):
         """Test that a BotControlEvent can be serialized to JSON and deserialized back."""
         event = BotControlEvent(
             kill=False,
-            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+            timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
             reason="Scheduled maintenance",
         )
         json_data = event.model_dump_json()
@@ -46,5 +47,6 @@ class TestBotControlEvent(unittest.TestCase):
         with self.assertRaises(ValueError):
             BotControlEvent(
                 kill="yes",  # type: ignore[arg-type]
+                timestamp=datetime.now(timezone.utc),
                 reason="Invalid kill value",
             )


### PR DESCRIPTION
This pull request introduces a new `BotControlEvent` model to represent bot control actions, such as killing a bot for a specific reason, and adds comprehensive unit tests to ensure its correctness and validation logic.

### New Model Introduction

* Added the `BotControlEvent` Pydantic model in `bot_control_event.py` to represent bot control events, including fields for `kill` (bool), `timestamp` (datetime), and a non-blank `reason` (string). Custom validators enforce that `kill` is strictly a boolean and `reason` is not blank.

### Testing and Validation

* Added unit tests in `test_bot_control_event.py` to verify:
  - Creation of valid `BotControlEvent` instances.
  - Enforcement of non-blank `reason` values.
  - JSON serialization and deserialization round-trip.
  - Type enforcement for the `kill` field (must be boolean).