### PR TITLE
37 32 kill switch global emergency stop

### DIFF
--- a/src/Nightwatch/kill_switch.py
+++ b/src/Nightwatch/kill_switch.py
@@ -1,7 +1,6 @@
 """Kill switch — global emergency stop for trading activity."""
 
 import logging
-from dataclasses import dataclass
 
 from Nightwatch.metrics import NightwatchMetrics
 from Nightwatch.models.bot_control_event import BotControlEvent
@@ -9,7 +8,6 @@ from Nightwatch.models.bot_control_event import BotControlEvent
 LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
 class KillSwitch:
     """Holds the current trading-enabled state, updated by BotControlEvents."""
 
@@ -20,6 +18,9 @@ class KillSwitch:
 
     def apply(self, event: BotControlEvent) -> None:
         """Update state from a BotControlEvent. NOT thread-safe; must be called from the asyncio event loop."""
+        if self.trading_enabled != (not event.kill):
+            if self._metrics is not None:
+                self._metrics.kill_switch_toggles_total.inc()
         self.trading_enabled = not event.kill
         LOGGER.info(
             "Kill switch updated: trading_enabled=%s reason=%s timestamp=%s",
@@ -27,5 +28,3 @@ class KillSwitch:
             event.reason,
             event.timestamp,
         )
-        if not self.trading_enabled and self._metrics is not None:
-            self._metrics.kill_switch_toggles_total.inc()

--- a/src/Nightwatch/kill_switch.py
+++ b/src/Nightwatch/kill_switch.py
@@ -3,16 +3,20 @@
 import logging
 from dataclasses import dataclass
 
+from Nightwatch.metrics import NightwatchMetrics
 from Nightwatch.models.bot_control_event import BotControlEvent
 
 LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(slots=True)
+@dataclass
 class KillSwitch:
     """Holds the current trading-enabled state, updated by BotControlEvents."""
 
-    trading_enabled: bool = True
+    def __init__(self, metrics: NightwatchMetrics | None = None) -> None:
+        """Initialize with trading enabled by default."""
+        self.trading_enabled: bool = True
+        self._metrics = metrics
 
     def apply(self, event: BotControlEvent) -> None:
         """Update state from a BotControlEvent. NOT thread-safe; must be called from the asyncio event loop."""
@@ -23,3 +27,5 @@ class KillSwitch:
             event.reason,
             event.timestamp,
         )
+        if not self.trading_enabled and self._metrics is not None:
+            self._metrics.kill_switch_toggles_total.inc()

--- a/src/Nightwatch/kill_switch.py
+++ b/src/Nightwatch/kill_switch.py
@@ -1,22 +1,21 @@
 """Kill switch — global emergency stop for trading activity."""
 
 import logging
-
-from pydantic import BaseModel, ConfigDict, Field
+from dataclasses import dataclass
 
 from Nightwatch.models.bot_control_event import BotControlEvent
 
 LOGGER = logging.getLogger(__name__)
 
 
-class KillSwitch(BaseModel):
+@dataclass(slots=True)
+class KillSwitch:
     """Holds the current trading-enabled state, updated by BotControlEvents."""
 
-    model_config = ConfigDict(validate_assignment=True)
-    trading_enabled: bool = Field(default=True)
+    trading_enabled: bool = True
 
     def apply(self, event: BotControlEvent) -> None:
-        """Update state from a BotControlEvent (kill=True → disabled)."""
+        """Update state from a BotControlEvent (kill=True -> disabled)."""
         self.trading_enabled = not event.kill
         LOGGER.info(
             "Kill switch updated: trading_enabled=%s reason=%s",

--- a/src/Nightwatch/kill_switch.py
+++ b/src/Nightwatch/kill_switch.py
@@ -18,7 +18,8 @@ class KillSwitch:
         """Update state from a BotControlEvent. NOT thread-safe; must be called from the asyncio event loop."""
         self.trading_enabled = not event.kill
         LOGGER.info(
-            "Kill switch updated: trading_enabled=%s reason=%s",
+            "Kill switch updated: trading_enabled=%s reason=%s timestamp=%s",
             self.trading_enabled,
             event.reason,
+            event.timestamp,
         )

--- a/src/Nightwatch/kill_switch.py
+++ b/src/Nightwatch/kill_switch.py
@@ -15,7 +15,7 @@ class KillSwitch:
     trading_enabled: bool = True
 
     def apply(self, event: BotControlEvent) -> None:
-        """Update state from a BotControlEvent (kill=True -> disabled)."""
+        """Update state from a BotControlEvent. NOT thread-safe; must be called from the asyncio event loop."""
         self.trading_enabled = not event.kill
         LOGGER.info(
             "Kill switch updated: trading_enabled=%s reason=%s",

--- a/src/Nightwatch/messaging/control_event_publisher.py
+++ b/src/Nightwatch/messaging/control_event_publisher.py
@@ -15,10 +15,8 @@ LOGGER = logging.getLogger(__name__)
 CONTROL_SUBJECT = "control.bot"
 CONTROL_STREAM_NAME = "CONTROL"
 
-# Retain the last 10 000 control events; messages older than 24 h are discarded.
-# This prevents unbounded disk growth for StorageType.FILE streams.
 _STREAM_MAX_MSGS = 10_000
-_STREAM_MAX_AGE_SECONDS = 86_400  # 24 hours in seconds
+_STREAM_MAX_AGE_SECONDS = 86_400
 
 
 class ControlEventPublisher(NatsConnector):

--- a/src/Nightwatch/messaging/control_event_subscriber.py
+++ b/src/Nightwatch/messaging/control_event_subscriber.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Awaitable, Callable
 
+from nats.aio.subscription import Subscription
 from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy
 from nats.js.client import JetStreamContext
 from pydantic import ValidationError
@@ -19,7 +21,6 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_DURABLE_NAME = "trade-service"
 
-# Maximum redelivery attempts for a single message before JetStream marks it as dead-lettered.
 _MAX_DELIVER = 5
 
 
@@ -36,6 +37,7 @@ class ControlEventSubscriber(NatsConnector):
         """Initialize the ControlEventSubscriber with NATS connection parameters."""
         super().__init__(config=config, metrics=metrics)
         self._subscription: JetStreamContext.PushSubscription | None = None
+        self._advisory_sub: Subscription | None = None
 
     async def subscribe(
         self,
@@ -43,6 +45,7 @@ class ControlEventSubscriber(NatsConnector):
         *,
         durable: str = DEFAULT_DURABLE_NAME,
         ack_wait: float = 30.0,
+        deliver_policy: DeliverPolicy = DeliverPolicy.LAST,
     ) -> None:
         """Subscribe to control.bot with a durable JetStream consumer.
 
@@ -56,6 +59,9 @@ class ControlEventSubscriber(NatsConnector):
             cb: Callback invoked with each successfully parsed BotControlEvent.
             durable: Name of the durable consumer (persists across restarts).
             ack_wait: Seconds JetStream waits before redelivering an unacked message.
+            deliver_policy: JetStream delivery policy for the durable consumer.
+                Defaults to DeliverPolicy.LAST so a restarted subscriber recovers
+                the most recent state without replaying the full history.
         """
         if not self.client.is_connected:
             LOGGER.warning("NATS subscriber is not connected. Calling connect().")
@@ -68,7 +74,7 @@ class ControlEventSubscriber(NatsConnector):
 
         consumer_config = ConsumerConfig(
             durable_name=durable,
-            deliver_policy=DeliverPolicy.LAST,
+            deliver_policy=deliver_policy,
             ack_policy=AckPolicy.EXPLICIT,
             ack_wait=ack_wait,
             max_deliver=_MAX_DELIVER,
@@ -96,5 +102,48 @@ class ControlEventSubscriber(NatsConnector):
             cb=_handler,
             manual_ack=True,
         )
+
+        if self._advisory_sub is not None:
+            await self._advisory_sub.unsubscribe()
+
+        advisory_subject = f"$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.{CONTROL_STREAM_NAME}.{durable}"
+
+        async def _advisory_handler(msg: Any) -> None:
+            try:
+                data: dict[str, Any] = json.loads(msg.data)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                data = {}
+            stream_seq = data.get("stream_seq", "unknown")
+            deliveries = data.get("deliveries", _MAX_DELIVER)
+            LOGGER.critical(
+                "BotControlEvent dead-lettered after %s delivery attempts "
+                "(stream=%s, consumer=%s, stream_seq=%s). "
+                "A kill command may not have been processed — manual intervention required.",
+                deliveries,
+                CONTROL_STREAM_NAME,
+                durable,
+                stream_seq,
+            )
+            if self._metrics is not None:
+                self._metrics.control_events_dead_lettered_total.inc()
+
+        self._advisory_sub = await self.client.subscribe(advisory_subject, cb=_advisory_handler)
+
         await self.client.flush()
         LOGGER.debug("Subscribed to '%s' with durable consumer '%s'.", CONTROL_SUBJECT, durable)
+        LOGGER.debug("Watching dead-letter advisory on '%s'.", advisory_subject)
+
+    async def close(self) -> None:
+        """Unsubscribe advisory and JetStream subscriptions before closing the connection.
+
+        Cleans up both the dead-letter advisory core-NATS subscription and the
+        durable JetStream push subscription so that no callbacks fire after the
+        connection is drained.
+        """
+        if self._advisory_sub is not None:
+            await self._advisory_sub.unsubscribe()
+            self._advisory_sub = None
+        if self._subscription is not None:
+            await self._subscription.unsubscribe()
+            self._subscription = None
+        await super().close()

--- a/src/Nightwatch/messaging/control_event_subscriber.py
+++ b/src/Nightwatch/messaging/control_event_subscriber.py
@@ -68,7 +68,7 @@ class ControlEventSubscriber(NatsConnector):
 
         consumer_config = ConsumerConfig(
             durable_name=durable,
-            deliver_policy=DeliverPolicy.NEW,
+            deliver_policy=DeliverPolicy.LAST,
             ack_policy=AckPolicy.EXPLICIT,
             ack_wait=ack_wait,
             max_deliver=_MAX_DELIVER,

--- a/src/Nightwatch/messaging/control_event_subscriber.py
+++ b/src/Nightwatch/messaging/control_event_subscriber.py
@@ -110,9 +110,11 @@ class ControlEventSubscriber(NatsConnector):
 
         async def _advisory_handler(msg: Any) -> None:
             try:
-                data: dict[str, Any] = json.loads(msg.data)
+                parsed_data: Any = json.loads(msg.data)
             except (json.JSONDecodeError, UnicodeDecodeError):
-                data = {}
+                data: dict[str, Any] = {}
+            else:
+                data = parsed_data if isinstance(parsed_data, dict) else {}
             stream_seq = data.get("stream_seq", "unknown")
             deliveries = data.get("deliveries", _MAX_DELIVER)
             LOGGER.critical(

--- a/src/Nightwatch/metrics.py
+++ b/src/Nightwatch/metrics.py
@@ -27,6 +27,8 @@ class NightwatchMetrics:
     signals_rejected_total: Counter = field(init=False)
     control_events_published_total: Counter = field(init=False)
     control_events_received_total: Counter = field(init=False)
+    control_events_dead_lettered_total: Counter = field(init=False)
+    kill_switch_toggles_total: Counter = field(init=False)
 
     def __post_init__(self) -> None:
         """Create Prometheus counters bound to the instance registry."""
@@ -101,6 +103,16 @@ class NightwatchMetrics:
         self.control_events_received_total = Counter(
             "control_events_received_total",
             "Total number of control events received by the subscriber",
+            registry=self.registry,
+        )
+        self.control_events_dead_lettered_total = Counter(
+            "control_events_dead_lettered_total",
+            "Total number of control events dead-lettered after exhausting max delivery attempts",
+            registry=self.registry,
+        )
+        self.kill_switch_toggles_total = Counter(
+            "kill_switch_toggles_total",
+            "Total number of kill switch toggles",
             registry=self.registry,
         )
 

--- a/src/Nightwatch/models/signal.py
+++ b/src/Nightwatch/models/signal.py
@@ -1,7 +1,7 @@
 """Define the Signal model for representing Signals."""
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
 
@@ -29,6 +29,14 @@ class Signal(BaseModel):
     schema_version: int
 
     model_config = ConfigDict(str_max_length=255)
+
+    @field_validator("timestamp")
+    @classmethod
+    def timestamp_must_be_timezone_aware(cls, v: datetime) -> datetime:
+        """Require timezone-aware timestamps and normalize them to UTC."""
+        if v.tzinfo is None or v.utcoffset() is None:
+            raise ValueError("timestamp must be timezone-aware")
+        return v.astimezone(timezone.utc)
 
     @field_validator("symbol")
     @classmethod

--- a/src/Nightwatch/models/tick_buffer.py
+++ b/src/Nightwatch/models/tick_buffer.py
@@ -65,3 +65,7 @@ class TickBuffer:
         """Return ticks for *symbol* that fall within the last *seconds* seconds."""
         cutoff = datetime.now(timezone.utc) - timedelta(seconds=seconds)
         return deque(t for t in self.ticks.get(symbol, []) if t.timestamp >= cutoff)
+
+    def clear_ticks(self, symbol: str) -> None:
+        """Clear all ticks for *symbol*."""
+        self.ticks[symbol].clear()

--- a/src/Nightwatch/risk_engine.py
+++ b/src/Nightwatch/risk_engine.py
@@ -28,6 +28,8 @@ class RiskEngine:
             metrics: Optional NightwatchMetrics instance for recording metrics. If not provided, no metrics will be recorded.
         """
         self._rules = rules
+        if len(self._rules) == 0:
+            raise ValueError("RiskEngine must be initialized with at least one rule.")
         self._metrics = metrics
 
     @classmethod

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -35,10 +35,7 @@ class StrategyRunner:
     def on_market_tick(self, tick: MarketTick) -> Signal | None:
         """Process a market tick and determine if a trading signal should be emitted. Return None if Kill switch is active."""
         first_tick = self._buffer.get_first_tick(tick.symbol)
-        if not self._kill_switch.trading_enabled:
-            if self._metric:
-                self._metric.signals_suppressed_total.labels(reason="kill_switch").inc()
-            LOGGER.debug("Kill switch is active — suppressing tick for %s", tick.symbol)
+        if self._is_suppressed_by_kill_switch(tick):
             return None
 
         self._buffer.add_tick(tick)
@@ -88,3 +85,12 @@ class StrategyRunner:
             }
             LOGGER.info(json.dumps(log, default=str))
         return signal
+
+    def _is_suppressed_by_kill_switch(self, tick: MarketTick) -> bool:
+        """Check if the kill switch is active and log suppression if so."""
+        if not self._kill_switch.trading_enabled:
+            if self._metric:
+                self._metric.signals_suppressed_total.labels(reason="kill_switch").inc()
+            LOGGER.debug("Kill switch active — suppressing %s", tick.symbol)
+            return True
+        return False

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -35,13 +35,13 @@ class StrategyRunner:
     def on_market_tick(self, tick: MarketTick) -> Signal | None:
         """Process a market tick and determine if a trading signal should be emitted. Return None if Kill switch is active."""
         first_tick = self._buffer.get_first_tick(tick.symbol)
-        self._buffer.add_tick(tick)
         if not self._kill_switch.trading_enabled:
             if self._metric:
                 self._metric.signals_suppressed_total.labels(reason="kill_switch").inc()
             LOGGER.debug("Kill switch is active — suppressing tick for %s", tick.symbol)
             return None
 
+        self._buffer.add_tick(tick)
         if not first_tick:
             if self._metric:
                 self._metric.signals_suppressed_total.labels(reason="first_tick").inc()

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -3,8 +3,8 @@
 import json
 import logging
 
+from Nightwatch.kill_switch import KillSwitch
 from Nightwatch.metrics import NightwatchMetrics
-from Nightwatch.models.kill_switch import KillSwitch
 from Nightwatch.models.market_tick import MarketTick
 from Nightwatch.models.signal import Signal
 from Nightwatch.models.tick_buffer import TickBuffer

--- a/tests/Nightwatch/test_bot_control_event.py
+++ b/tests/Nightwatch/test_bot_control_event.py
@@ -26,7 +26,7 @@ class TestBotControlEvent(unittest.TestCase):
             BotControlEvent(
                 kill=True,
                 timestamp=datetime.now(timezone.utc),
-                reason="   ",  # Just whitespace
+                reason="   ",
             )
 
     def test_json_roundtrip(self) -> None:

--- a/tests/Nightwatch/test_control_event_subscriber.py
+++ b/tests/Nightwatch/test_control_event_subscriber.py
@@ -1,0 +1,211 @@
+# mypy: disable-error-code="import-untyped"
+"""Unit tests for ControlEventSubscriber — dead-letter advisory handler and message handler."""
+
+import asyncio
+import json
+import logging
+import unittest
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from prometheus_client import CollectorRegistry
+
+from Nightwatch.messaging.control_event_subscriber import _MAX_DELIVER, ControlEventSubscriber
+from Nightwatch.metrics import NightwatchMetrics
+from Nightwatch.models.bot_control_event import BotControlEvent
+from Nightwatch.models.nats_config import NatsConnectionConfig
+
+
+def _counter_value(counter: Any) -> float:
+    """Return the current value of a labelless Prometheus counter."""
+    for mf in counter.collect():
+        for sample in mf.samples:
+            if sample.name.endswith("_total"):
+                return float(sample.value)
+    return 0.0
+
+
+class TestControlEventSubscriber(unittest.TestCase):
+    """Unit tests for ControlEventSubscriber dead-letter advisory and message handlers."""
+
+    def setUp(self) -> None:
+        registry = CollectorRegistry()
+        self.metrics = NightwatchMetrics(registry=registry)
+        self.subscriber = ControlEventSubscriber(
+            config=NatsConnectionConfig(servers=["nats://localhost:4222"]),
+            metrics=self.metrics,
+        )
+
+    def _run(self, coro: Any) -> Any:
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _build_mock_client(
+        self,
+        captured_advisory_cb: list[Any],
+        captured_msg_cb: list[Any] | None = None,
+    ) -> MagicMock:
+        """Return a mocked NatsClient that captures advisory and message callbacks."""
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+
+        mock_push_sub = AsyncMock()
+        mock_js = AsyncMock()
+
+        async def _fake_js_subscribe(**kwargs: Any) -> AsyncMock:
+            if captured_msg_cb is not None:
+                captured_msg_cb.append(kwargs.get("cb"))
+            return mock_push_sub
+
+        mock_js.subscribe = _fake_js_subscribe
+        mock_client.jetstream.return_value = mock_js
+
+        async def _fake_nats_subscribe(_subject: str, cb: Any) -> AsyncMock:
+            captured_advisory_cb.append(cb)
+            return AsyncMock()
+
+        mock_client.subscribe = _fake_nats_subscribe
+        mock_client.flush = AsyncMock()
+        return mock_client
+
+    def _subscribe_and_get_callbacks(
+        self,
+        cb: Any = None,
+        durable: str = "test-consumer",
+    ) -> tuple[Any, Any]:
+        """Run subscribe() with a mocked client and return (advisory_handler, message_handler)."""
+        advisory_cbs: list[Any] = []
+        msg_cbs: list[Any] = []
+        mock_client = self._build_mock_client(advisory_cbs, msg_cbs)
+        self.subscriber._nc = mock_client
+        self._run(self.subscriber.subscribe(cb, durable=durable))
+        self.assertEqual(len(advisory_cbs), 1, "Expected exactly one advisory callback to be registered")
+        self.assertEqual(len(msg_cbs), 1, "Expected exactly one message callback to be registered")
+        return advisory_cbs[0], msg_cbs[0]
+
+    @staticmethod
+    def _make_msg(data: bytes) -> AsyncMock:
+        msg = AsyncMock()
+        msg.data = data
+        return msg
+
+    def test_advisory_logs_critical_and_increments_metric(self) -> None:
+        """Advisory handler emits a CRITICAL log and increments control_events_dead_lettered_total."""
+        advisory_cb, _ = self._subscribe_and_get_callbacks()
+
+        payload = json.dumps({"stream_seq": 42, "deliveries": _MAX_DELIVER}).encode()
+        before = _counter_value(self.metrics.control_events_dead_lettered_total)
+
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL) as log_ctx:
+            self._run(advisory_cb(self._make_msg(payload)))
+
+        self.assertTrue(any("dead-lettered" in line for line in log_ctx.output))
+        self.assertEqual(_counter_value(self.metrics.control_events_dead_lettered_total), before + 1)
+
+    def test_advisory_logs_stream_seq_from_payload(self) -> None:
+        """Advisory handler includes the stream_seq value from the advisory payload in the CRITICAL log."""
+        advisory_cb, _ = self._subscribe_and_get_callbacks()
+
+        payload = json.dumps({"stream_seq": 99, "deliveries": _MAX_DELIVER}).encode()
+
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL) as log_ctx:
+            self._run(advisory_cb(self._make_msg(payload)))
+
+        self.assertTrue(any("99" in line for line in log_ctx.output))
+
+    def test_advisory_handles_invalid_json_without_raising(self) -> None:
+        """Advisory handler recovers from a corrupt advisory payload and still logs CRITICAL."""
+        advisory_cb, _ = self._subscribe_and_get_callbacks()
+
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL) as log_ctx:
+            self._run(advisory_cb(self._make_msg(b"not-valid-json!!!")))
+
+        self.assertTrue(any("dead-lettered" in line for line in log_ctx.output))
+        self.assertEqual(_counter_value(self.metrics.control_events_dead_lettered_total), 1.0)
+
+    def test_advisory_uses_unknown_default_for_missing_stream_seq(self) -> None:
+        """Advisory handler falls back to 'unknown' for stream_seq when the field is absent in the payload."""
+        advisory_cb, _ = self._subscribe_and_get_callbacks()
+
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL) as log_ctx:
+            self._run(advisory_cb(self._make_msg(json.dumps({}).encode())))
+
+        self.assertTrue(any("unknown" in line for line in log_ctx.output))
+
+    def test_advisory_without_metrics_does_not_raise(self) -> None:
+        """Advisory handler fires correctly even when no NightwatchMetrics instance is provided."""
+        subscriber_no_metrics = ControlEventSubscriber(
+            config=NatsConnectionConfig(servers=["nats://localhost:4222"]),
+            metrics=None,
+        )
+        advisory_cbs: list[Any] = []
+        mock_client = self._build_mock_client(advisory_cbs)
+        subscriber_no_metrics._nc = mock_client
+
+        self._run(subscriber_no_metrics.subscribe(None, durable="no-metrics-consumer"))
+
+        payload = json.dumps({"stream_seq": 7, "deliveries": _MAX_DELIVER}).encode()
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL):
+            self._run(advisory_cbs[0](self._make_msg(payload)))
+
+    def test_advisory_increments_counter_on_each_dead_letter(self) -> None:
+        """Each dead-letter advisory increments the counter independently."""
+        advisory_cb, _ = self._subscribe_and_get_callbacks()
+
+        payload = json.dumps({"stream_seq": 1, "deliveries": _MAX_DELIVER}).encode()
+
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL):
+            self._run(advisory_cb(self._make_msg(payload)))
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL):
+            self._run(advisory_cb(self._make_msg(payload)))
+
+        self.assertEqual(_counter_value(self.metrics.control_events_dead_lettered_total), 2.0)
+
+    def test_message_handler_terminates_poison_message(self) -> None:
+        """Handler calls term() and increments parse_errors_total for an unparsable message."""
+        _, msg_cb = self._subscribe_and_get_callbacks()
+
+        mock_msg = self._make_msg(b"this is not valid json")
+        before = _counter_value(self.metrics.parse_errors_total)
+
+        self._run(msg_cb(mock_msg))
+
+        mock_msg.term.assert_called_once()
+        mock_msg.ack.assert_not_called()
+        self.assertEqual(_counter_value(self.metrics.parse_errors_total), before + 1)
+
+    def test_message_handler_acks_valid_event_and_calls_callback(self) -> None:
+        """Handler acks a valid BotControlEvent, invokes the user callback, and increments received counter."""
+        received: list[BotControlEvent] = []
+
+        async def _cb(e: BotControlEvent) -> None:
+            received.append(e)
+
+        _, msg_cb = self._subscribe_and_get_callbacks(cb=_cb, durable="ack-test")
+
+        event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="unit test")
+        mock_msg = self._make_msg(event.model_dump_json().encode())
+
+        self._run(msg_cb(mock_msg))
+
+        mock_msg.ack.assert_called_once()
+        mock_msg.term.assert_not_called()
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].reason, "unit test")
+        self.assertEqual(_counter_value(self.metrics.control_events_received_total), 1.0)
+
+    def test_message_handler_acks_valid_event_without_callback(self) -> None:
+        """Handler acks a valid BotControlEvent even when no user callback is provided."""
+        _, msg_cb = self._subscribe_and_get_callbacks(cb=None)
+
+        event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="no-cb test")
+        mock_msg = self._make_msg(event.model_dump_json().encode())
+
+        self._run(msg_cb(mock_msg))
+
+        mock_msg.ack.assert_called_once()
+        mock_msg.term.assert_not_called()

--- a/tests/Nightwatch/test_integration_control_event.py
+++ b/tests/Nightwatch/test_integration_control_event.py
@@ -204,11 +204,12 @@ class TestControlEventIntegration(unittest.TestCase):
         self._run(_test())
 
     def test_kill_on_restart_replays_last_state(self) -> None:
-        """A BotControlEvent with kill=True and a restart event should replay the last state."""
+        """Verify DeliverPolicy.LAST recovers state after subscriber restart."""
 
         async def _test() -> None:
-            # Publish a kill event, then restart the subscriber and verify it receives the last state.
-            await self.publisher.publish(_make_event(kill=True, reason="kill on restart test"))
+            # Publish an event, then subscribe with DeliverPolicy.LAST to get the most recent message.
+            event = _make_event(reason="restart state recovery test")
+            await self.publisher.publish(event)
 
             received: list[BotControlEvent] = []
             received_event = asyncio.Event()
@@ -217,16 +218,23 @@ class TestControlEventIntegration(unittest.TestCase):
                 received.append(e)
                 received_event.set()
 
-            # Restart the subscriber with a durable name to receive the last state.
-            await self.subscriber.close()
-            self.subscriber = ControlEventSubscriber(config=NatsConnectionConfig(servers=[self.nats.url]), metrics=self.metric)
-            await self.subscriber.connect()
-            await self.subscriber.subscribe(on_event, durable="ts-restart-test")
+            await self.subscriber.subscribe(on_event, durable="ts-restart-test", deliver_policy=DeliverPolicy.LAST)
 
             await asyncio.wait_for(received_event.wait(), timeout=5.0)
 
             self.assertEqual(len(received), 1)
-            self.assertTrue(received[0].kill)
-            self.assertEqual(received[0].reason, "kill on restart test")
+            self.assertEqual(received[0].reason, event.reason)
+            self.assertEqual(received[0].kill, event.kill)
+
+        self._run(_test())
+
+    def test_control_subscriber_no_callback_does_not_raise(self) -> None:
+        """Subscribing without a callback does not raise an error."""
+
+        async def _test() -> None:
+            await self.subscriber.subscribe(None, durable="no-callback-test")
+            # Publish an event to ensure the subscription is active, but we don't care about receiving it.
+            await self.publisher.publish(_make_event(reason="no callback test"))
+            # If we reach this point without an exception, the test passes.
 
         self._run(_test())

--- a/tests/Nightwatch/test_integration_control_event.py
+++ b/tests/Nightwatch/test_integration_control_event.py
@@ -202,3 +202,31 @@ class TestControlEventIntegration(unittest.TestCase):
             self.assertEqual(_counter_value(self.metric.control_events_received_total), before_rcv + 1)
 
         self._run(_test())
+
+    def test_kill_on_restart_replays_last_state(self) -> None:
+        """A BotControlEvent with kill=True and a restart event should replay the last state."""
+
+        async def _test() -> None:
+            # Publish a kill event, then restart the subscriber and verify it receives the last state.
+            await self.publisher.publish(_make_event(kill=True, reason="kill on restart test"))
+
+            received: list[BotControlEvent] = []
+            received_event = asyncio.Event()
+
+            async def on_event(e: BotControlEvent) -> None:
+                received.append(e)
+                received_event.set()
+
+            # Restart the subscriber with a durable name to receive the last state.
+            await self.subscriber.close()
+            self.subscriber = ControlEventSubscriber(config=NatsConnectionConfig(servers=[self.nats.url]), metrics=self.metric)
+            await self.subscriber.connect()
+            await self.subscriber.subscribe(on_event, durable="ts-restart-test")
+
+            await asyncio.wait_for(received_event.wait(), timeout=5.0)
+
+            self.assertEqual(len(received), 1)
+            self.assertTrue(received[0].kill)
+            self.assertEqual(received[0].reason, "kill on restart test")
+
+        self._run(_test())

--- a/tests/Nightwatch/test_integration_control_event.py
+++ b/tests/Nightwatch/test_integration_control_event.py
@@ -81,10 +81,6 @@ class TestControlEventIntegration(unittest.TestCase):
     def _run(self, coro: Coroutine[Any, Any, Any]) -> Any:
         return self.loop.run_until_complete(coro)
 
-    # ------------------------------------------------------------------
-    # Given a running JetStream-enabled NATS server
-    # ------------------------------------------------------------------
-
     def test_given_connected_publisher_when_publish_then_no_error(self) -> None:
         """Publishing a BotControlEvent via JetStream succeeds without error."""
 
@@ -105,8 +101,6 @@ class TestControlEventIntegration(unittest.TestCase):
                 received.append(e)
                 received_event.set()
 
-            # Subscribe first (DeliverPolicy.NEW means only messages arriving
-            # AFTER consumer creation are delivered), then publish.
             await self.subscriber.subscribe(on_event, durable="ts-rcv-test")
 
             original = _make_event(reason="integration test receive")
@@ -127,8 +121,6 @@ class TestControlEventIntegration(unittest.TestCase):
             delivery_count = 0
             redelivered_event = asyncio.Event()
 
-            # Use a fresh publisher / subscriber pair on the same NATS server
-            # so we can control the durable consumer independently.
             config = NatsConnectionConfig(servers=[self.nats.url])
 
             pub = ControlEventPublisher(config=config)
@@ -143,15 +135,13 @@ class TestControlEventIntegration(unittest.TestCase):
                 delivery_count += 1
                 if delivery_count >= _MIN_REDELIVERY_COUNT:
                     redelivered_event.set()
-                # Do not ack — JetStream will redeliver after ack_wait.
 
-            # Access the raw JetStream subscribe so we can skip acking manually.
             js = sub.client.jetstream()
             consumer_config = ConsumerConfig(
                 durable_name="no-ack-consumer",
                 deliver_policy=DeliverPolicy.NEW,
                 ack_policy=AckPolicy.EXPLICIT,
-                ack_wait=1.0,  # 1-second ack wait so the test runs fast
+                ack_wait=1.0,
                 max_deliver=5,
             )
 
@@ -164,7 +154,6 @@ class TestControlEventIntegration(unittest.TestCase):
 
             await pub.publish(_make_event(reason="no-ack redelivery test"))
 
-            # Drain messages without acking until we see at least 2 deliveries.
             deadline = asyncio.get_event_loop().time() + 10.0
             while not redelivered_event.is_set() and asyncio.get_event_loop().time() < deadline:
                 try:
@@ -207,7 +196,6 @@ class TestControlEventIntegration(unittest.TestCase):
         """Verify DeliverPolicy.LAST recovers state after subscriber restart."""
 
         async def _test() -> None:
-            # Publish an event, then subscribe with DeliverPolicy.LAST to get the most recent message.
             event = _make_event(reason="restart state recovery test")
             await self.publisher.publish(event)
 
@@ -233,8 +221,6 @@ class TestControlEventIntegration(unittest.TestCase):
 
         async def _test() -> None:
             await self.subscriber.subscribe(None, durable="no-callback-test")
-            # Publish an event to ensure the subscription is active, but we don't care about receiving it.
             await self.publisher.publish(_make_event(reason="no callback test"))
-            # If we reach this point without an exception, the test passes.
 
         self._run(_test())

--- a/tests/Nightwatch/test_integration_kill_switch.py
+++ b/tests/Nightwatch/test_integration_kill_switch.py
@@ -91,20 +91,16 @@ class TestKillSwitchStopsSignalsViaNats(unittest.TestCase):
         base_ts = datetime.now(timezone.utc)
 
         async def _activate_and_verify() -> None:
-            # Wire the control subscriber to apply events to the kill switch.
             async def _on_control_event(event: BotControlEvent) -> None:
                 self.kill_switch.apply(event)
 
             await self.control_subscriber.subscribe(_on_control_event, durable="kill-switch-test")
 
-            # Wire the tick subscriber to run the strategy runner.
             async def _on_tick(tick: MarketTick) -> None:
                 self.runner.on_market_tick(tick)
 
             await self.tick_subscriber.subscribe(subject="market.tick.>", cb=_on_tick)
 
-            # Publish a rising sequence so the strategy generates at least one signal
-            # before the stop event fires.
             pre_stop_ticks = make_tick_sequence(
                 prices=[Decimal("50000"), Decimal("55001")],
                 start=base_ts,
@@ -114,10 +110,8 @@ class TestKillSwitchStopsSignalsViaNats(unittest.TestCase):
             for tick in pre_stop_ticks:
                 await self.tick_publisher.publish(tick, flush=True)
 
-            # Wait briefly for subscriber to process ticks.
             await asyncio.sleep(0.5)
 
-            # Publish a stop event and wait for the control subscriber to apply it.
             stop_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="integration test stop")
             await self.control_publisher.publish(stop_event)
 
@@ -129,7 +123,6 @@ class TestKillSwitchStopsSignalsViaNats(unittest.TestCase):
 
         self._run(_activate_and_verify())
 
-        # With kill switch now active, publish more ticks and assert they are suppressed.
         async def _assert_ticks_suppressed() -> None:
             suppressed_before = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch") or 0.0
 
@@ -142,7 +135,6 @@ class TestKillSwitchStopsSignalsViaNats(unittest.TestCase):
             for tick in post_stop_ticks:
                 await self.tick_publisher.publish(tick, flush=True)
 
-            # Allow time for subscriber to process ticks.
             await asyncio.sleep(0.5)
 
             suppressed_after = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch") or 0.0

--- a/tests/Nightwatch/test_integration_kill_switch.py
+++ b/tests/Nightwatch/test_integration_kill_switch.py
@@ -10,13 +10,13 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
+from Nightwatch.kill_switch import KillSwitch
 from Nightwatch.messaging.control_event_publisher import ControlEventPublisher
 from Nightwatch.messaging.control_event_subscriber import ControlEventSubscriber
 from Nightwatch.messaging.publisher import MarketTickPublisher
 from Nightwatch.messaging.subscriber import MarketTickSubscriber
 from Nightwatch.metrics import NightwatchMetrics
 from Nightwatch.models.bot_control_event import BotControlEvent
-from Nightwatch.models.kill_switch import KillSwitch
 from Nightwatch.models.market_tick import MarketTick
 from Nightwatch.models.nats_config import NatsConnectionConfig
 from Nightwatch.models.tick_buffer import TickBuffer

--- a/tests/Nightwatch/test_integration_price_ingestion.py
+++ b/tests/Nightwatch/test_integration_price_ingestion.py
@@ -92,7 +92,6 @@ class TestPriceIngestionIntegration(unittest.TestCase):
             self.assertEqual(payload["source"], "Kraken")
             self.assertEqual(payload["schema_version"], 1)
 
-            # Round-trip: reconstruct a MarketTick from the payload
             reconstructed = MarketTick(**payload)
             self.assertEqual(reconstructed.uid, tick.uid)
             self.assertEqual(Decimal(reconstructed.price), Decimal(tick.price))

--- a/tests/Nightwatch/test_integration_strategy_runner.py
+++ b/tests/Nightwatch/test_integration_strategy_runner.py
@@ -108,12 +108,9 @@ class TestSignalsTotalViaNats(unittest.TestCase):
             except asyncio.TimeoutError:
                 pass
 
-            # Flush remaining messages and give subscriber time to process.
             await self.publisher.client.flush()
             await asyncio.sleep(2.0)
 
-            # Feed synthetic ticks with a guaranteed large price spread so
-            # that the strategy fires regardless of real-market conditions.
             latest = self.buffer.get_latest_tick(symbol="BTC/USD")
             base_price = latest.price if latest else Decimal("50000")
             base_ts = latest.timestamp if latest else datetime.now(timezone.utc)

--- a/tests/Nightwatch/test_kill_switch.py
+++ b/tests/Nightwatch/test_kill_switch.py
@@ -4,9 +4,9 @@ import unittest
 from datetime import datetime, timezone
 from decimal import Decimal
 
+from Nightwatch.kill_switch import KillSwitch
 from Nightwatch.metrics import NightwatchMetrics
 from Nightwatch.models.bot_control_event import BotControlEvent
-from Nightwatch.models.kill_switch import KillSwitch
 from Nightwatch.models.tick_buffer import TickBuffer
 from Nightwatch.risk_engine import RiskEngine
 from Nightwatch.rules.max_signal_per_minute_rule import MaxSignalPerMinuteRule

--- a/tests/Nightwatch/test_kill_switch.py
+++ b/tests/Nightwatch/test_kill_switch.py
@@ -2,7 +2,7 @@
 """Unit tests for the KillSwitch model in the Nightwatch application."""
 
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from Nightwatch.kill_switch import KillSwitch
@@ -81,40 +81,48 @@ class TestKillSwitch(unittest.TestCase):
     def test_kill_switch_idempotent(self) -> None:
         """Test that applying the same BotControlEvent multiple times does not change the state after the first application."""
         kill_switch = KillSwitch()
-        event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Idempotent test")
-        kill_switch.apply(event)
+        true_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Idempotent true test")
+        false_event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Idempotent false test")
+
+        kill_switch.apply(true_event)
         self.assertFalse(kill_switch.trading_enabled)
-        kill_switch.apply(event)  # Applying the same event again should not change the state
+        kill_switch.apply(true_event)  # Applying the same event again should not change the state
         self.assertFalse(kill_switch.trading_enabled)
+
+        kill_switch.apply(false_event)
+        self.assertTrue(kill_switch.trading_enabled)
+        kill_switch.apply(false_event)  # Applying the same event again should not change the state
+        self.assertTrue(kill_switch.trading_enabled)
 
     def test_resume_after_kill_emits_signal_only_on_fresh_ticks(self) -> None:
-        """Test that resuming trading after a kill switch event only allows signals to be emitted on new ticks, not old ones."""
-        strategy = AlwaysSignalStrategy()
-        buffer = TickBuffer()
+        """Given kill=ON ticks ignored, when kill=OFF, then signal requires N new ticks."""
         metric = NightwatchMetrics()
-        kill_switch = KillSwitch()
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, kill_switch=kill_switch)
+        strategy = AlwaysSignalStrategy()
+        buffer = TickBuffer(max_ticks_per_symbol=30)
+        risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
+        kill_switch = KillSwitch()  # trading_enabled=True by default
+        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
 
-        # Apply kill switch
-        kill_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Testing resume")
+        # Apply kill switch ON
+        kill_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Testing kill switch")
         kill_switch.apply(kill_event)
 
-        # Feed a tick while kill switch is active (should be suppressed)
-        tick1 = make_tick()
-        signal1 = runner.on_market_tick(tick1)
-        self.assertIsNone(signal1)
-        suppressed_after_kill = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
-        self.assertEqual(suppressed_after_kill, 1.0)
+        # Feed some ticks while kill switch is ON (these should be ignored)
+        for _ in range(5):
+            tick = make_tick()
+            signal = runner.on_market_tick(tick)
+            self.assertIsNone(signal)
 
-        # Resume trading
+        # Apply kill switch OFF
         resume_event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Resuming trading")
         kill_switch.apply(resume_event)
 
-        # Feed the same tick again (should not emit signal since it's not fresh)
-        signal2 = runner.on_market_tick(tick1)
-        self.assertIsNone(signal2)
+        # Feed a tick immediately after resuming (should not emit signal because it's not a fresh tick)
+        tick_after_resume = make_tick()
+        signal_after_resume = runner.on_market_tick(tick_after_resume)
+        self.assertIsNone(signal_after_resume)
 
-        # Feed a new tick (should be processed normally)
-        tick2 = make_tick(timestamp=tick1.timestamp + timedelta(seconds=10))
-        signal3 = runner.on_market_tick(tick2)
-        self.assertIsNotNone(signal3)
+        # Feed another tick (this should emit a signal because it's a fresh tick after resuming)
+        next_tick = make_tick()
+        signal_next_tick = runner.on_market_tick(next_tick)
+        self.assertIsNotNone(signal_next_tick)

--- a/tests/Nightwatch/test_kill_switch.py
+++ b/tests/Nightwatch/test_kill_switch.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="import-untyped"
 """Unit tests for the KillSwitch model in the Nightwatch application."""
 
 import unittest
@@ -76,3 +77,12 @@ class TestKillSwitch(unittest.TestCase):
         self.assertIsNotNone(signal)
         suppressed = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
         self.assertEqual(suppressed, 0.0)
+
+    def test_kill_switch_idempotent(self) -> None:
+        """Test that applying the same BotControlEvent multiple times does not change the state after the first application."""
+        kill_switch = KillSwitch()
+        event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Idempotent test")
+        kill_switch.apply(event)
+        self.assertFalse(kill_switch.trading_enabled)
+        kill_switch.apply(event)  # Applying the same event again should not change the state
+        self.assertFalse(kill_switch.trading_enabled)

--- a/tests/Nightwatch/test_kill_switch.py
+++ b/tests/Nightwatch/test_kill_switch.py
@@ -2,7 +2,7 @@
 """Unit tests for the KillSwitch model in the Nightwatch application."""
 
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 from Nightwatch.kill_switch import KillSwitch
@@ -13,7 +13,7 @@ from Nightwatch.risk_engine import RiskEngine
 from Nightwatch.rules.max_signal_per_minute_rule import MaxSignalPerMinuteRule
 from Nightwatch.strategies.momentum_burst import MomentumBurstStrategy
 from Nightwatch.strategy_runner import StrategyRunner
-from tests.fixtures.test_strategy import NoneStrategy
+from tests.fixtures.test_strategy import AlwaysSignalStrategy, NoneStrategy
 from tests.fixtures.tick_factory import feed_ticks, make_tick, make_tick_sequence
 
 
@@ -86,3 +86,35 @@ class TestKillSwitch(unittest.TestCase):
         self.assertFalse(kill_switch.trading_enabled)
         kill_switch.apply(event)  # Applying the same event again should not change the state
         self.assertFalse(kill_switch.trading_enabled)
+
+    def test_resume_after_kill_emits_signal_only_on_fresh_ticks(self) -> None:
+        """Test that resuming trading after a kill switch event only allows signals to be emitted on new ticks, not old ones."""
+        strategy = AlwaysSignalStrategy()
+        buffer = TickBuffer()
+        metric = NightwatchMetrics()
+        kill_switch = KillSwitch()
+        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, kill_switch=kill_switch)
+
+        # Apply kill switch
+        kill_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Testing resume")
+        kill_switch.apply(kill_event)
+
+        # Feed a tick while kill switch is active (should be suppressed)
+        tick1 = make_tick()
+        signal1 = runner.on_market_tick(tick1)
+        self.assertIsNone(signal1)
+        suppressed_after_kill = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
+        self.assertEqual(suppressed_after_kill, 1.0)
+
+        # Resume trading
+        resume_event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Resuming trading")
+        kill_switch.apply(resume_event)
+
+        # Feed the same tick again (should not emit signal since it's not fresh)
+        signal2 = runner.on_market_tick(tick1)
+        self.assertIsNone(signal2)
+
+        # Feed a new tick (should be processed normally)
+        tick2 = make_tick(timestamp=tick1.timestamp + timedelta(seconds=10))
+        signal3 = runner.on_market_tick(tick2)
+        self.assertIsNotNone(signal3)

--- a/tests/Nightwatch/test_kill_switch.py
+++ b/tests/Nightwatch/test_kill_switch.py
@@ -34,7 +34,7 @@ class TestKillSwitch(unittest.TestCase):
 
     def test_trading_activated_by_bot_control_event(self) -> None:
         """Test that applying a BotControlEvent with kill=False enables trading."""
-        kill_switch = KillSwitch(trading_enabled=False)
+        kill_switch = KillSwitch()
         event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Resume trading")
         kill_switch.apply(event)
         self.assertTrue(kill_switch.trading_enabled)
@@ -62,7 +62,7 @@ class TestKillSwitch(unittest.TestCase):
         strategy = MomentumBurstStrategy(threshold_pct=10, metric=metric)
         buffer = TickBuffer(max_ticks_per_symbol=30)
         risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
-        kill_switch = KillSwitch()  # trading_enabled=True by default
+        kill_switch = KillSwitch()
         runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
 
         start_time = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
@@ -86,12 +86,12 @@ class TestKillSwitch(unittest.TestCase):
 
         kill_switch.apply(true_event)
         self.assertFalse(kill_switch.trading_enabled)
-        kill_switch.apply(true_event)  # Applying the same event again should not change the state
+        kill_switch.apply(true_event)
         self.assertFalse(kill_switch.trading_enabled)
 
         kill_switch.apply(false_event)
         self.assertTrue(kill_switch.trading_enabled)
-        kill_switch.apply(false_event)  # Applying the same event again should not change the state
+        kill_switch.apply(false_event)
         self.assertTrue(kill_switch.trading_enabled)
 
     def test_resume_after_kill_emits_signal_only_on_fresh_ticks(self) -> None:
@@ -100,29 +100,24 @@ class TestKillSwitch(unittest.TestCase):
         strategy = AlwaysSignalStrategy()
         buffer = TickBuffer(max_ticks_per_symbol=30)
         risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
-        kill_switch = KillSwitch()  # trading_enabled=True by default
+        kill_switch = KillSwitch()
         runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
 
-        # Apply kill switch ON
         kill_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Testing kill switch")
         kill_switch.apply(kill_event)
 
-        # Feed some ticks while kill switch is ON (these should be ignored)
         for _ in range(5):
             tick = make_tick()
             signal = runner.on_market_tick(tick)
             self.assertIsNone(signal)
 
-        # Apply kill switch OFF
         resume_event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Resuming trading")
         kill_switch.apply(resume_event)
 
-        # Feed a tick immediately after resuming (should not emit signal because it's not a fresh tick)
         tick_after_resume = make_tick()
         signal_after_resume = runner.on_market_tick(tick_after_resume)
         self.assertIsNone(signal_after_resume)
 
-        # Feed another tick (this should emit a signal because it's a fresh tick after resuming)
         next_tick = make_tick()
         signal_next_tick = runner.on_market_tick(next_tick)
         self.assertIsNotNone(signal_next_tick)

--- a/tests/Nightwatch/test_kraken_adapter.py
+++ b/tests/Nightwatch/test_kraken_adapter.py
@@ -195,12 +195,12 @@ class TestKrakenAdapter(unittest.TestCase):
 
     def test_no_metrics_does_not_crash(self) -> None:
         """Given no metrics injected, when a bad message arrives, then no AttributeError."""
-        adapter = KrakenAdapter()  # metrics=None
+        adapter = KrakenAdapter()
         result = adapter.parse_message({"channel": "ticker", "data": []})
         self.assertIsNone(result)
 
     def test_no_metrics_does_not_crash_with_invalid_data(self) -> None:
         """Given no metrics injected, when a bad message arrives, then no AttributeError."""
-        adapter = KrakenAdapter()  # metrics=None
+        adapter = KrakenAdapter()
         result = adapter.parse_message({"channel": "ticker", "data": ["invalid"]})
         self.assertIsNone(result)

--- a/tests/Nightwatch/test_risk_engine.py
+++ b/tests/Nightwatch/test_risk_engine.py
@@ -93,3 +93,9 @@ class TestRiskEngine(unittest.TestCase):
         self.assertEqual(
             self.metrics.get_counter_value(self.metrics.signals_rejected_total, symbol=self.signal.symbol, rule="CooldownRule"), 1
         )
+
+    def test_create_default_rule_order(self) -> None:
+        """Test that the default rules are created in the expected order ala the contract."""
+        engine = RiskEngine.create_default()
+        rule_names = [r.name for r in engine._rules]
+        self.assertEqual(rule_names, ["CooldownRule", "MinTradeStrengthRule", "MaxSignalPerMinuteRule"])

--- a/tests/Nightwatch/test_rules.py
+++ b/tests/Nightwatch/test_rules.py
@@ -29,12 +29,12 @@ class TestRules(unittest.TestCase):
     def test_cooldown_rule_blocks_signal_within_cooldown(self) -> None:
         """Test that CooldownRule blocks a second signal within the cooldown period."""
         decision1 = self.cooldown_rule.evaluate(self.signal)
-        self.assertIsNone(decision1)  # First signal should be allowed
+        self.assertIsNone(decision1)
         if decision1 is None:
             self.cooldown_rule.confirm(self.signal)
 
         decision2 = self.cooldown_rule.evaluate(self.signal)
-        self.assertIsNotNone(decision2)  # Second signal should be blocked
+        self.assertIsNotNone(decision2)
         self.assertFalse(decision2.allowed)
         self.assertEqual(decision2.reason, "Cooldown active")
         self.assertEqual(decision2.rule, "CooldownRule")
@@ -43,7 +43,7 @@ class TestRules(unittest.TestCase):
         """Test that MinTradeStrengthRule blocks a signal with strength below the minimum."""
         weak_signal = make_signal(strength=1.0)
         decision = self.min_trade_strength_rule.evaluate(weak_signal)
-        self.assertIsNotNone(decision)  # Signal should be blocked
+        self.assertIsNotNone(decision)
         self.assertFalse(decision.allowed)
         self.assertEqual(decision.reason, "Trade strength below minimum")
         self.assertEqual(decision.rule, "MinTradeStrengthRule")
@@ -112,14 +112,14 @@ class TestRules(unittest.TestCase):
             rule.confirm(signal1)
 
         decision2 = rule.evaluate(signal2)
-        self.assertIsNotNone(decision2)  # Should be blocked
+        self.assertIsNotNone(decision2)
         self.assertFalse(decision2.allowed)
 
         decision3 = rule.evaluate(signal3)
-        self.assertIsNone(decision3)  # Should be allowed after cleanup
+        self.assertIsNone(decision3)
         if decision3 is None:
             rule.confirm(signal3)
-        self.assertEqual(len(rule._last_seen), 1)  # Only the entry for signal3 should remain
+        self.assertEqual(len(rule._last_seen), 1)
 
     def test_clean_up_cooldown_rule(self) -> None:
         """Test that CooldownRule cleans up old entries from _last_seen."""
@@ -135,11 +135,11 @@ class TestRules(unittest.TestCase):
             rule.confirm(signal1)
 
         decision2 = rule.evaluate(signal2)
-        self.assertIsNotNone(decision2)  # Should be blocked
+        self.assertIsNotNone(decision2)
         self.assertFalse(decision2.allowed)
 
         decision3 = rule.evaluate(signal3)
-        self.assertIsNone(decision3)  # Should be allowed after cleanup
+        self.assertIsNone(decision3)
         if decision3 is None:
             rule.confirm(signal3)
-        self.assertEqual(len(rule._last_seen), 1)  # Only the entry for signal3 should remain
+        self.assertEqual(len(rule._last_seen), 1)

--- a/tests/Nightwatch/test_signal.py
+++ b/tests/Nightwatch/test_signal.py
@@ -2,7 +2,7 @@
 
 import unittest
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 from Nightwatch.models.signal import Side, Signal
@@ -104,3 +104,15 @@ class TestSignal(unittest.TestCase):
                 source="trade-service",
                 schema_version=1,
             )
+
+    def test_naive_timestamp_raises(self) -> None:
+        """Test that timezone-naive timestamps are rejected."""
+        with self.assertRaises(ValueError):
+            make_signal(timestamp=datetime(2026, 1, 1, 12, 0, 0))
+
+    def test_timestamp_is_normalized_to_utc(self) -> None:
+        """Test that timezone-aware timestamps are normalized to UTC."""
+        local_tz = timezone(timedelta(hours=2))
+        signal = make_signal(timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=local_tz))
+        self.assertEqual(signal.timestamp.tzinfo, timezone.utc)
+        self.assertEqual(signal.timestamp, datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc))

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -100,7 +100,6 @@ class TestStrategyRunner(unittest.TestCase):
         risk_engine = RiskEngine(rules=[MinTradeStrengthRule(min_strength=50.0)])
         runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine)
 
-        # delta_pct = 15%, strength = 15.0, which is below min_strength=50
         ticks = make_tick_sequence(
             prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
@@ -157,7 +156,6 @@ class TestStrategyRunner(unittest.TestCase):
         signal1 = feed_ticks(runner, ticks)
         self.assertIsNotNone(signal1)
 
-        # Second qualifying tick — strategy fires but MaxSignalPerMinuteRule rejects
         tick2 = make_tick(price=Decimal("135"), timestamp=self.start_time + timedelta(seconds=10))
         signal2 = runner.on_market_tick(tick2)
         self.assertIsNone(signal2)
@@ -173,7 +171,6 @@ class TestStrategyRunner(unittest.TestCase):
         risk_engine = RiskEngine(rules=[MinTradeStrengthRule(min_strength=1.0), MaxSignalPerMinuteRule(max_signals_per_min=1000)])
         runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine)
 
-        # delta_pct = 15%, strength = 15.0 — above min_strength=1.0, within rate limit
         ticks = make_tick_sequence(
             prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
@@ -189,10 +186,8 @@ class TestStrategyRunner(unittest.TestCase):
         metric = NightwatchMetrics()
         strategy = MomentumBurstStrategy(threshold_pct=1, window_sec=60, metric=metric)
         buffer = TickBuffer(max_ticks_per_symbol=30)
-        # No risk_engine provided — default includes MinTradeStrengthRule(min_strength=10)
         runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric)
 
-        # delta_pct = 5%, strength = 5.0, below default min_strength=10
         ticks = make_tick_sequence(prices=[Decimal("100"), Decimal("105")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD")
         signal = feed_ticks(runner, ticks)
         self.assertIsNone(signal)
@@ -205,24 +200,18 @@ class TestStrategyRunner(unittest.TestCase):
         metric = NightwatchMetrics()
         strategy = MomentumBurstStrategy(threshold_pct=10, window_sec=60, metric=metric)
         buffer = TickBuffer(max_ticks_per_symbol=30)
-        # CooldownRule is first; MinTradeStrengthRule second
         risk_engine = RiskEngine(rules=[CooldownRule(cooldown_seconds=999), MinTradeStrengthRule(min_strength=50.0)])
         runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine)
 
-        # Signal 1: delta_pct=55% → strength=55 ≥ 50 → passes both rules → CooldownRule confirm() called
         ticks = make_tick_sequence(prices=[Decimal("100"), Decimal("155")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD")
         signal1 = feed_ticks(runner, ticks)
         self.assertIsNotNone(signal1)
         self.assertEqual(metric.get_counter_value(metric.signals_suppressed_total, reason="MinTradeStrengthRule") or 0.0, 0.0)
 
-        # Signal 2 at t+65s: window covers [t+5s..t+65s], start_price=155, end_price=172
-        # delta_pct ≈ 10.97% → strategy fires; strength ≈ 10.97 < 50 → MinTradeStrengthRule would reject
-        # but CooldownRule fires first (65s < 999s cooldown)
         tick2 = make_tick(price=Decimal("172"), timestamp=self.start_time + timedelta(seconds=65))
         runner.on_market_tick(tick2)
         cooldown_suppressed = metric.get_counter_value(metric.signals_suppressed_total, reason="CooldownRule") or 0.0
         self.assertEqual(cooldown_suppressed, 1.0)
-        # MinTradeStrengthRule count unchanged — proves CooldownRule rejected first, short-circuiting the chain
         min_suppressed_after = metric.get_counter_value(metric.signals_suppressed_total, reason="MinTradeStrengthRule") or 0.0
         self.assertEqual(min_suppressed_after, 0.0)
 
@@ -234,19 +223,16 @@ class TestStrategyRunner(unittest.TestCase):
         risk_engine = RiskEngine(rules=[MinTradeStrengthRule(min_strength=1.0)])
         runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine)
 
-        # Initial ticks trigger a signal
         ticks1 = make_tick_sequence(
             prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
         )
         signal1 = feed_ticks(runner, ticks1)
         self.assertIsNotNone(signal1)
 
-        # Simulate pause by clearing buffer and waiting
         buffer.clear_ticks("BTC/USD")
         pause_duration = timedelta(seconds=120)
         resume_time = self.start_time + pause_duration
 
-        # New ticks after resume should not be affected by old ticks
         ticks2 = make_tick_sequence(
             prices=[Decimal("200"), Decimal("210"), Decimal("230")], start=resume_time, interval_sec=5.0, symbol="BTC/USD"
         )

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -225,3 +225,30 @@ class TestStrategyRunner(unittest.TestCase):
         # MinTradeStrengthRule count unchanged — proves CooldownRule rejected first, short-circuiting the chain
         min_suppressed_after = metric.get_counter_value(metric.signals_suppressed_total, reason="MinTradeStrengthRule") or 0.0
         self.assertEqual(min_suppressed_after, 0.0)
+
+    def test_buffer_not_contaminated_after_resume(self) -> None:
+        """After a pause and resume, the buffer should not contain stale ticks that could trigger false signals."""
+        metric = NightwatchMetrics()
+        strategy = MomentumBurstStrategy(threshold_pct=10, window_sec=60, metric=metric)
+        buffer = TickBuffer(max_ticks_per_symbol=30)
+        risk_engine = RiskEngine(rules=[MinTradeStrengthRule(min_strength=1.0)])
+        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine)
+
+        # Initial ticks trigger a signal
+        ticks1 = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
+        )
+        signal1 = feed_ticks(runner, ticks1)
+        self.assertIsNotNone(signal1)
+
+        # Simulate pause by clearing buffer and waiting
+        buffer.clear_ticks("BTC/USD")
+        pause_duration = timedelta(seconds=120)
+        resume_time = self.start_time + pause_duration
+
+        # New ticks after resume should not be affected by old ticks
+        ticks2 = make_tick_sequence(
+            prices=[Decimal("200"), Decimal("210"), Decimal("230")], start=resume_time, interval_sec=5.0, symbol="BTC/USD"
+        )
+        signal2 = feed_ticks(runner, ticks2)
+        self.assertIsNotNone(signal2)

--- a/tests/Nightwatch/test_unit_tick_buffer.py
+++ b/tests/Nightwatch/test_unit_tick_buffer.py
@@ -25,7 +25,7 @@ class TestTickBuffer(unittest.TestCase):
             tick = make_tick(price=Decimal(str(i)))
             self.buffer.add_tick(tick)
         self.assertEqual(len(self.buffer.get_ticks("BTC/USD")), 3)
-        self.assertEqual(self.buffer.get_ticks("BTC/USD")[0].price, Decimal("1"))  # oldest evicted
+        self.assertEqual(self.buffer.get_ticks("BTC/USD")[0].price, Decimal("1"))
 
     def test_given_two_symbols_when_ticks_added_then_isolated(self) -> None:
         """Test that ticks for different symbols are stored in separate buffers and do not interfere with each other."""

--- a/tests/fixtures/test_strategy.py
+++ b/tests/fixtures/test_strategy.py
@@ -9,7 +9,7 @@ from Nightwatch.models.strategy_decision import StrategyDecision
 from Nightwatch.strategies.strategy import Strategy
 
 
-class NoneStrategy(Strategy):  # type: ignore[misc]
+class NoneStrategy(Strategy):
     """A concrete implementation of the Strategy class for testing purposes."""
 
     NAME = "none_strategy"
@@ -23,7 +23,7 @@ class NoneStrategy(Strategy):  # type: ignore[misc]
         return None
 
 
-class AlwaysSignalStrategy(Strategy):  # type: ignore[misc]
+class AlwaysSignalStrategy(Strategy):
     """A concrete implementation of the Strategy class that always emits a BUY signal."""
 
     NAME = "always_signal_strategy"

--- a/tests/fixtures/test_strategy.py
+++ b/tests/fixtures/test_strategy.py
@@ -8,7 +8,7 @@ from Nightwatch.models.strategy_decision import StrategyDecision
 from Nightwatch.strategies.strategy import Strategy
 
 
-class NoneStrategy(Strategy):
+class NoneStrategy(Strategy):  # type: ignore[misc]
     """A concrete implementation of the Strategy class for testing purposes."""
 
     NAME = "none_strategy"

--- a/tests/fixtures/test_strategy.py
+++ b/tests/fixtures/test_strategy.py
@@ -4,6 +4,7 @@
 from collections import deque
 
 from Nightwatch.models.market_tick import MarketTick
+from Nightwatch.models.signal import Side
 from Nightwatch.models.strategy_decision import StrategyDecision
 from Nightwatch.strategies.strategy import Strategy
 
@@ -20,3 +21,18 @@ class NoneStrategy(Strategy):  # type: ignore[misc]
     def on_tick(self, symbol: str, window: deque[MarketTick]) -> StrategyDecision | None:  # noqa: ARG002
         """A simple implementation of the on_tick method that always returns None."""
         return None
+
+
+class AlwaysSignalStrategy(Strategy):  # type: ignore[misc]
+    """A concrete implementation of the Strategy class that always emits a BUY signal."""
+
+    NAME = "always_signal_strategy"
+
+    def __init__(self) -> None:
+        """Initialize the Strategy class."""
+        super().__init__()
+
+    def on_tick(self, symbol: str, window: deque[MarketTick]) -> StrategyDecision | None:  # noqa: ARG002
+        """Always returns a BUY StrategyDecision."""
+
+        return StrategyDecision(side=Side.BUY, strength=100.0, rationale={})


### PR DESCRIPTION
This pull request introduces several important improvements to the kill switch, metrics, and control event handling subsystems, along with some general code quality enhancements. The main themes are a robust redesign of the kill switch logic, improved observability for control events (including dead-letter tracking), and enhanced validation and safety in several models and services.

**Kill switch redesign and observability:**

* Replaced the previous Pydantic-based `KillSwitch` with a new dataclass implementation in `kill_switch.py`, improving clarity, logging, and integration with Prometheus metrics. The kill switch now increments a metric on toggles and logs reasons and timestamps for state changes. (`src/Nightwatch/kill_switch.py`, `src/Nightwatch/models/kill_switch.py`) [[1]](diffhunk://#diff-78bfb95ac8fd0666b8fbf9b8f699376e88d27ac9d73ffa410703cc030b172739R1-R31) [[2]](diffhunk://#diff-e8136db9d8fce2a281ddc45e834e5fbd9995af2652754f41631d212cba0e9960L1-L25)
* Updated `strategy_runner.py` to use the new `KillSwitch` implementation, refactored tick suppression logic for clarity, and improved logging and metric incrementing when the kill switch is active. (`src/Nightwatch/strategy_runner.py`) [[1]](diffhunk://#diff-e6b82a06d3753ccca8faeca36049b5c4dc3e926937ee3f53963af08d6c63266eR6-L7) [[2]](diffhunk://#diff-e6b82a06d3753ccca8faeca36049b5c4dc3e926937ee3f53963af08d6c63266eL38-R41) [[3]](diffhunk://#diff-e6b82a06d3753ccca8faeca36049b5c4dc3e926937ee3f53963af08d6c63266eR88-R96)

**Metrics enhancements:**

* Added Prometheus counters for dead-lettered control events and kill switch toggles to `NightwatchMetrics`, enabling better monitoring of system health and operator interventions. (`src/Nightwatch/metrics.py`) [[1]](diffhunk://#diff-a937d8c3c2f3ffbb9874833803dd39a2a693dd37ccd36de0fac78ffcf78714ffR30-R31) [[2]](diffhunk://#diff-a937d8c3c2f3ffbb9874833803dd39a2a693dd37ccd36de0fac78ffcf78714ffR108-R117)

**Control event handling improvements:**

* Improved the `ControlEventSubscriber` to subscribe to JetStream advisory subjects for dead-lettered control events, log critical incidents when max delivery attempts are exhausted, and increment a new dead-letter metric. Also added a `close()` method for proper cleanup of subscriptions. (`src/Nightwatch/messaging/control_event_subscriber.py`) [[1]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R5-R9) [[2]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4L22) [[3]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R40-R48) [[4]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R62-R64) [[5]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4L71-R77) [[6]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R105-R149)
* Changed the default JetStream delivery policy for control event consumers to `DeliverPolicy.LAST`, ensuring that on restart, subscribers recover only the latest state and do not replay the entire event history. (`src/Nightwatch/messaging/control_event_subscriber.py`) [[1]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R40-R48) [[2]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R62-R64) [[3]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4L71-R77)
* Minor documentation and style cleanups in the control event publisher and subscriber. (`src/Nightwatch/messaging/control_event_publisher.py`, `src/Nightwatch/messaging/control_event_subscriber.py`) [[1]](diffhunk://#diff-eb4e507f661f964d01975636a69f2fbdd0ce9ca1097d873c965efa361121adbeL18-R19) [[2]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4L22)

**Model validation and safety:**

* Added a validator to the `Signal` model to require timezone-aware timestamps and normalize them to UTC, improving data consistency. (`src/Nightwatch/models/signal.py`) [[1]](diffhunk://#diff-1fede2b88fbf9d4bb9713e3dbeedafa3a48d5c8db30a21e5d7f82a199d43822cL4-R4) [[2]](diffhunk://#diff-1fede2b88fbf9d4bb9713e3dbeedafa3a48d5c8db30a21e5d7f82a199d43822cR33-R40)
* Added a check to ensure `RiskEngine` cannot be initialized without at least one rule, preventing misconfiguration. (`src/Nightwatch/risk_engine.py`)
* Added a `clear_ticks` method to `TickBuffer` for completeness and potential test utility. (`src/Nightwatch/models/tick_buffer.py`)

These changes collectively improve the reliability, observability, and maintainability of the trading system's control and risk infrastructure.