### PR TITLE
37 32 kill switch global emergency stop

### DIFF
--- a/src/Nightwatch/messaging/control_event_subscriber.py
+++ b/src/Nightwatch/messaging/control_event_subscriber.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from typing import Any, Awaitable, Callable
 
 from nats.aio.subscription import Subscription
@@ -39,6 +40,7 @@ class ControlEventSubscriber(NatsConnector):
         super().__init__(config=config, metrics=metrics)
         self._subscription: JetStreamContext.PushSubscription | None = None
         self._advisory_sub: Subscription | None = None
+        self._uid = uuid.uuid4()
 
     async def subscribe(
         self,
@@ -154,6 +156,7 @@ class ControlEventSubscriber(NatsConnector):
         Returns:
             The number of events applied (0 or 1).
         """
+        LOGGER.info("Draining JetStream backlog for control events with timeout %.1f seconds...", timeout)
         if not self.client.is_connected:
             LOGGER.warning("NATS subscriber is not connected. Calling connect().")
             await self.connect()
@@ -161,6 +164,7 @@ class ControlEventSubscriber(NatsConnector):
         js = self.client.jetstream()
 
         sub = await js.subscribe(
+            durable=f"drain-consumer-{self._uid}",
             subject=CONTROL_SUBJECT,
             stream=CONTROL_STREAM_NAME,
             config=ConsumerConfig(
@@ -168,6 +172,7 @@ class ControlEventSubscriber(NatsConnector):
                 ack_policy=AckPolicy.EXPLICIT,
             ),
         )
+        LOGGER.info("Subscribed to JetStream with ephemeral consumer to drain backlog: %s", sub)
 
         applied = 0
         try:

--- a/src/Nightwatch/messaging/control_event_subscriber.py
+++ b/src/Nightwatch/messaging/control_event_subscriber.py
@@ -42,7 +42,7 @@ class ControlEventSubscriber(NatsConnector):
 
     async def subscribe(
         self,
-        cb: Callable[[BotControlEvent], Awaitable[Any]] | None = None,
+        cb: Callable[[BotControlEvent], Awaitable[Any]],
         *,
         durable: str = DEFAULT_DURABLE_NAME,
         ack_wait: float = 30.0,
@@ -92,8 +92,7 @@ class ControlEventSubscriber(NatsConnector):
                 return
             if self._metrics:
                 self._metrics.control_events_received_total.inc()
-            if cb is not None:
-                await cb(event)
+            await cb(event)
             await msg.ack()
 
         self._subscription = await js.subscribe(

--- a/src/Nightwatch/messaging/control_event_subscriber.py
+++ b/src/Nightwatch/messaging/control_event_subscriber.py
@@ -164,9 +164,10 @@ class ControlEventSubscriber(NatsConnector):
             await self.connect()
 
         js = self.client.jetstream()
+        drain_consumer_name = f"drain-consumer-{self._uid}"
 
         sub = await js.subscribe(
-            durable=f"drain-consumer-{self._uid}",
+            durable=drain_consumer_name,
             subject=CONTROL_SUBJECT,
             stream=CONTROL_STREAM_NAME,
             config=ConsumerConfig(
@@ -192,6 +193,11 @@ class ControlEventSubscriber(NatsConnector):
             LOGGER.info("No pending control events in JetStream backlog.")
         finally:
             await sub.unsubscribe()
+            try:
+                await js.delete_consumer(CONTROL_STREAM_NAME, drain_consumer_name)
+                LOGGER.debug("Deleted ephemeral drain consumer '%s'.", drain_consumer_name)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Could not delete drain consumer '%s': %s", drain_consumer_name, exc)
 
         kill_switch.mark_ready()
         LOGGER.info("Backlog drain complete: %d event(s) applied, kill switch ready.", applied)

--- a/src/Nightwatch/messaging/control_event_subscriber.py
+++ b/src/Nightwatch/messaging/control_event_subscriber.py
@@ -22,7 +22,7 @@ from Nightwatch.models.nats_config import NatsConnectionConfig
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_DURABLE_NAME = "trade-service"
-
+_DEFAULT_DELIVER_POLICY = DeliverPolicy.LAST
 _MAX_DELIVER = 5
 
 
@@ -48,7 +48,7 @@ class ControlEventSubscriber(NatsConnector):
         *,
         durable: str = DEFAULT_DURABLE_NAME,
         ack_wait: float = 30.0,
-        deliver_policy: DeliverPolicy = DeliverPolicy.LAST,
+        deliver_policy: DeliverPolicy = _DEFAULT_DELIVER_POLICY,
     ) -> None:
         """Subscribe to control.bot with a durable JetStream consumer.
 
@@ -63,9 +63,11 @@ class ControlEventSubscriber(NatsConnector):
             durable: Name of the durable consumer (persists across restarts).
             ack_wait: Seconds JetStream waits before redelivering an unacked message.
             deliver_policy: JetStream delivery policy for the durable consumer.
-                Defaults to DeliverPolicy.LAST so a restarted subscriber recovers
+                Defaults to _DEFAULT_DELIVER_POLICY so a restarted subscriber recovers
                 the most recent state without replaying the full history.
         """
+        if cb is None:
+            raise ValueError("Callback function must be provided for subscription.")
         if not self.client.is_connected:
             LOGGER.warning("NATS subscriber is not connected. Calling connect().")
             await self.connect()
@@ -168,7 +170,7 @@ class ControlEventSubscriber(NatsConnector):
             subject=CONTROL_SUBJECT,
             stream=CONTROL_STREAM_NAME,
             config=ConsumerConfig(
-                deliver_policy=DeliverPolicy.LAST,
+                deliver_policy=_DEFAULT_DELIVER_POLICY,
                 ack_policy=AckPolicy.EXPLICIT,
             ),
         )

--- a/src/Nightwatch/rules/max_signal_per_minute_rule.py
+++ b/src/Nightwatch/rules/max_signal_per_minute_rule.py
@@ -56,7 +56,8 @@ class MaxSignalPerMinuteRule(RiskRule):
 
     def _cleanup_last_seen_dict(self, current_time: datetime) -> None:
         """Remove entries from _last_seen that are outside the 1-minute window."""
-        cutoff = current_time.timestamp() - 60
         self._last_seen = SortedDict(
-            (key, timestamps) for key, timestamps in self._last_seen.items() if timestamps and timestamps[-1].timestamp() >= cutoff
+            (key, timestamps)
+            for key, timestamps in self._last_seen.items()
+            if timestamps and (current_time - timestamps[-1]).total_seconds() <= 60  # noqa: PLR2004
         )

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -114,7 +114,7 @@ class StrategyRunner:
     def _handle_resume(self, tick: MarketTick) -> None:
         """Clear stale pre-kill state and warm up the buffer with the first post-resume tick."""
         self._was_killed = False
-        symbols_cleared = sorted(self._buffer.ticks.keys())
+        symbols_cleared = sorted(symbol for symbol, ticks in self._buffer.ticks.items() if ticks)
         self._buffer.clear_all_ticks()
         self._buffer.add_tick(tick)
-        LOGGER.info("Buffers cleared for symbols: %s", ", ".join(symbols_cleared))
+        LOGGER.info("Buffers cleared for symbols: %s", ", ".join(symbols_cleared) if symbols_cleared else "none")

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -43,11 +43,8 @@ class StrategyRunner:
             return None
 
         if self._was_killed:
-            self._was_killed = False
-            self._buffer.clear_all_ticks()
-            self._buffer.add_tick(tick)
+            self._handle_resume(tick)
             first_tick = None
-            LOGGER.info("Kill switch resumed — cleared buffer for all symbols (triggered by %s)", tick.symbol)
 
         if not first_tick:
             if self._metric:
@@ -113,3 +110,11 @@ class StrategyRunner:
             source=tick.source,
             schema_version=tick.schema_version,
         )
+
+    def _handle_resume(self, tick: MarketTick) -> None:
+        """Clear stale pre-kill state and warm up the buffer with the first post-resume tick."""
+        self._was_killed = False
+        symbols_cleared = sorted(self._buffer.ticks.keys())
+        self._buffer.clear_all_ticks()
+        self._buffer.add_tick(tick)
+        LOGGER.info("Buffers cleared for symbols: %s", ", ".join(symbols_cleared))

--- a/src/Nightwatch/strategy_runner.py
+++ b/src/Nightwatch/strategy_runner.py
@@ -47,7 +47,7 @@ class StrategyRunner:
             self._buffer.clear_all_ticks()
             self._buffer.add_tick(tick)
             first_tick = None
-            LOGGER.info("Kill switch resumed — cleared buffer for %s", tick.symbol)
+            LOGGER.info("Kill switch resumed — cleared buffer for all symbols (triggered by %s)", tick.symbol)
 
         if not first_tick:
             if self._metric:

--- a/tests/Nightwatch/test_control_event_subscriber.py
+++ b/tests/Nightwatch/test_control_event_subscriber.py
@@ -146,7 +146,10 @@ class TestControlEventSubscriber(unittest.TestCase):
         mock_client = self._build_mock_client(advisory_cbs)
         subscriber_no_metrics._nc = mock_client
 
-        self._run(subscriber_no_metrics.subscribe(None, durable="no-metrics-consumer"))
+        async def _noop(e: BotControlEvent) -> None:
+            pass
+
+        self._run(subscriber_no_metrics.subscribe(_noop, durable="no-metrics-consumer"))
 
         payload = json.dumps({"stream_seq": 7, "deliveries": _MAX_DELIVER}).encode()
         with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.CRITICAL):
@@ -197,15 +200,3 @@ class TestControlEventSubscriber(unittest.TestCase):
         self.assertEqual(len(received), 1)
         self.assertEqual(received[0].reason, "unit test")
         self.assertEqual(_counter_value(self.metrics.control_events_received_total), 1.0)
-
-    def test_message_handler_acks_valid_event_without_callback(self) -> None:
-        """Handler acks a valid BotControlEvent even when no user callback is provided."""
-        _, msg_cb = self._subscribe_and_get_callbacks(cb=None)
-
-        event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="no-cb test")
-        mock_msg = self._make_msg(event.model_dump_json().encode())
-
-        self._run(msg_cb(mock_msg))
-
-        mock_msg.ack.assert_called_once()
-        mock_msg.term.assert_not_called()

--- a/tests/Nightwatch/test_control_event_subscriber.py
+++ b/tests/Nightwatch/test_control_event_subscriber.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from prometheus_client import CollectorRegistry
 
+from Nightwatch.kill_switch import KillSwitch
 from Nightwatch.messaging.control_event_subscriber import _MAX_DELIVER, ControlEventSubscriber
 from Nightwatch.metrics import NightwatchMetrics
 from Nightwatch.models.bot_control_event import BotControlEvent
@@ -72,6 +73,10 @@ class TestControlEventSubscriber(unittest.TestCase):
         mock_client.flush = AsyncMock()
         return mock_client
 
+    @staticmethod
+    async def _noop_cb(_event: BotControlEvent) -> None:
+        """Default no-op callback for tests that don't need to inspect received events."""
+
     def _subscribe_and_get_callbacks(
         self,
         cb: Any = None,
@@ -82,7 +87,7 @@ class TestControlEventSubscriber(unittest.TestCase):
         msg_cbs: list[Any] = []
         mock_client = self._build_mock_client(advisory_cbs, msg_cbs)
         self.subscriber._nc = mock_client
-        self._run(self.subscriber.subscribe(cb, durable=durable))
+        self._run(self.subscriber.subscribe(cb if cb is not None else self._noop_cb, durable=durable))
         self.assertEqual(len(advisory_cbs), 1, "Expected exactly one advisory callback to be registered")
         self.assertEqual(len(msg_cbs), 1, "Expected exactly one message callback to be registered")
         return advisory_cbs[0], msg_cbs[0]
@@ -200,3 +205,30 @@ class TestControlEventSubscriber(unittest.TestCase):
         self.assertEqual(len(received), 1)
         self.assertEqual(received[0].reason, "unit test")
         self.assertEqual(_counter_value(self.metrics.control_events_received_total), 1.0)
+
+    def test_subscribe_without_callback_raises_value_error(self) -> None:
+        """Calling subscribe() without a callback should raise a ValueError."""
+        with self.assertRaises(ValueError):
+            self._run(self.subscriber.subscribe(cb=None))  # type: ignore[arg-type]
+
+    def test_drain_backlog_logs_restored_state(self) -> None:
+        """Draining the backlog emits an info log with the restored kill-switch state."""
+        event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="backlog drain test")
+        mock_msg = self._make_msg(event.model_dump_json().encode())
+        mock_msg.ack = AsyncMock()
+        mock_sub = AsyncMock()
+        mock_sub.next_msg = AsyncMock(return_value=mock_msg)
+        mock_sub.unsubscribe = AsyncMock()
+        mock_js = AsyncMock()
+        mock_js.subscribe = AsyncMock(return_value=mock_sub)
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.jetstream.return_value = mock_js
+
+        self.subscriber._nc = mock_client
+        kill_switch = KillSwitch()
+
+        with self.assertLogs("Nightwatch.messaging.control_event_subscriber", level=logging.INFO) as log_ctx:
+            self._run(self.subscriber.drain_backlog(kill_switch))
+
+        self.assertTrue(any("Restored" in line and "trading_enabled=False" in line for line in log_ctx.output))

--- a/tests/Nightwatch/test_integration_control_event.py
+++ b/tests/Nightwatch/test_integration_control_event.py
@@ -215,12 +215,3 @@ class TestControlEventIntegration(unittest.TestCase):
             self.assertEqual(received[0].kill, event.kill)
 
         self._run(_test())
-
-    def test_control_subscriber_no_callback_does_not_raise(self) -> None:
-        """Subscribing without a callback does not raise an error."""
-
-        async def _test() -> None:
-            await self.subscriber.subscribe(None, durable="no-callback-test")
-            await self.publisher.publish(_make_event(reason="no callback test"))
-
-        self._run(_test())

--- a/tests/Nightwatch/test_kill_switch.py
+++ b/tests/Nightwatch/test_kill_switch.py
@@ -27,9 +27,6 @@ class TestKillSwitch(unittest.TestCase):
         self.always_strategy = AlwaysSignalStrategy()
         self.buffer = TickBuffer(max_ticks_per_symbol=30)
         self.metric = NightwatchMetrics()
-        self.strategy = AlwaysSignalStrategy()
-        self.buffer = TickBuffer(max_ticks_per_symbol=30)
-        self.risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
         self.kill_switch = KillSwitch()
 
     def test_trading_enabled_by_default(self) -> None:

--- a/tests/Nightwatch/test_kill_switch.py
+++ b/tests/Nightwatch/test_kill_switch.py
@@ -20,50 +20,53 @@ from tests.fixtures.tick_factory import feed_ticks, make_tick, make_tick_sequenc
 class TestKillSwitch(unittest.TestCase):
     """Unit tests for the KillSwitch model."""
 
+    def setUp(self) -> None:
+        """Set up common test data."""
+        self.none_strategy = NoneStrategy()
+        self.momentum_strategy = MomentumBurstStrategy(threshold_pct=10, metric=None)
+        self.always_strategy = AlwaysSignalStrategy()
+        self.buffer = TickBuffer(max_ticks_per_symbol=30)
+        self.metric = NightwatchMetrics()
+        self.strategy = AlwaysSignalStrategy()
+        self.buffer = TickBuffer(max_ticks_per_symbol=30)
+        self.risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
+        self.kill_switch = KillSwitch()
+
     def test_trading_enabled_by_default(self) -> None:
         """Test that trading is enabled by default."""
-        kill_switch = KillSwitch()
-        self.assertTrue(kill_switch.trading_enabled)
+        self.assertTrue(self.kill_switch.trading_enabled)
 
     def test_trading_disabled_by_bot_control_event(self) -> None:
         """Test that applying a BotControlEvent with kill=True disables trading."""
-        kill_switch = KillSwitch()
         event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Emergency stop")
-        kill_switch.apply(event)
-        self.assertFalse(kill_switch.trading_enabled)
+        self.kill_switch.apply(event)
+        self.assertFalse(self.kill_switch.trading_enabled)
 
     def test_trading_activated_by_bot_control_event(self) -> None:
         """Test that applying a BotControlEvent with kill=False enables trading."""
-        kill_switch = KillSwitch()
         event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Resume trading")
-        kill_switch.apply(event)
-        self.assertTrue(kill_switch.trading_enabled)
+        self.kill_switch.apply(event)
+        self.assertTrue(self.kill_switch.trading_enabled)
 
     def test_strategy_runner_respects_kill_switch(self) -> None:
         """Test that the StrategyRunner does not emit signals when the kill switch is active."""
-        strategy = NoneStrategy()
-        buffer = TickBuffer()
-        metric = NightwatchMetrics()
-        kill_switch = KillSwitch()
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, kill_switch=kill_switch)
+        runner = StrategyRunner(strategy=self.none_strategy, buffer=self.buffer, metric=self.metric, kill_switch=self.kill_switch)
 
         event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Testing kill switch")
-        kill_switch.apply(event)
-        before_kill_switch_metric = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
+        self.kill_switch.apply(event)
+        before_kill_switch_metric = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch") or 0.0
         tick = make_tick()
         signal = runner.on_market_tick(tick)
         self.assertIsNone(signal)
-        after_kill_switch_metric = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
+        after_kill_switch_metric = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch") or 0.0
         self.assertEqual(after_kill_switch_metric, before_kill_switch_metric + 1.0)
 
     def test_strategy_runner_processes_signals_when_kill_switch_inactive(self) -> None:
         """Test that the StrategyRunner emits signals normally when the kill switch is inactive."""
-        metric = NightwatchMetrics()
-        strategy = MomentumBurstStrategy(threshold_pct=10, metric=metric)
-        buffer = TickBuffer(max_ticks_per_symbol=30)
         risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
-        kill_switch = KillSwitch()
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
+        runner = StrategyRunner(
+            strategy=self.momentum_strategy, buffer=self.buffer, metric=self.metric, risk_engine=risk_engine, kill_switch=self.kill_switch
+        )
 
         start_time = datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
         ticks = make_tick_sequence(
@@ -75,36 +78,33 @@ class TestKillSwitch(unittest.TestCase):
         signal = feed_ticks(runner, ticks)
 
         self.assertIsNotNone(signal)
-        suppressed = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
+        suppressed = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch") or 0.0
         self.assertEqual(suppressed, 0.0)
 
     def test_kill_switch_idempotent(self) -> None:
         """Test that applying the same BotControlEvent multiple times does not change the state after the first application."""
-        kill_switch = KillSwitch()
         true_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Idempotent true test")
         false_event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Idempotent false test")
 
-        kill_switch.apply(true_event)
-        self.assertFalse(kill_switch.trading_enabled)
-        kill_switch.apply(true_event)
-        self.assertFalse(kill_switch.trading_enabled)
+        self.kill_switch.apply(true_event)
+        self.assertFalse(self.kill_switch.trading_enabled)
+        self.kill_switch.apply(true_event)
+        self.assertFalse(self.kill_switch.trading_enabled)
 
-        kill_switch.apply(false_event)
-        self.assertTrue(kill_switch.trading_enabled)
-        kill_switch.apply(false_event)
-        self.assertTrue(kill_switch.trading_enabled)
+        self.kill_switch.apply(false_event)
+        self.assertTrue(self.kill_switch.trading_enabled)
+        self.kill_switch.apply(false_event)
+        self.assertTrue(self.kill_switch.trading_enabled)
 
     def test_resume_after_kill_emits_signal_only_on_fresh_ticks(self) -> None:
         """Given kill=ON ticks ignored, when kill=OFF, then signal requires N new ticks."""
-        metric = NightwatchMetrics()
-        strategy = AlwaysSignalStrategy()
-        buffer = TickBuffer(max_ticks_per_symbol=30)
         risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
-        kill_switch = KillSwitch()
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
+        runner = StrategyRunner(
+            strategy=self.always_strategy, buffer=self.buffer, metric=self.metric, risk_engine=risk_engine, kill_switch=self.kill_switch
+        )
 
         kill_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Testing kill switch")
-        kill_switch.apply(kill_event)
+        self.kill_switch.apply(kill_event)
 
         for _ in range(5):
             tick = make_tick()
@@ -112,7 +112,7 @@ class TestKillSwitch(unittest.TestCase):
             self.assertIsNone(signal)
 
         resume_event = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Resuming trading")
-        kill_switch.apply(resume_event)
+        self.kill_switch.apply(resume_event)
 
         tick_after_resume = make_tick()
         signal_after_resume = runner.on_market_tick(tick_after_resume)
@@ -122,34 +122,22 @@ class TestKillSwitch(unittest.TestCase):
         signal_next_tick = runner.on_market_tick(next_tick)
         self.assertIsNotNone(signal_next_tick)
 
-    def test_ready_defaults_to_true(self) -> None:
-        """Test that KillSwitch defaults to ready=True for backward compatibility."""
-        kill_switch = KillSwitch()
-        self.assertTrue(kill_switch.ready)
-
     def test_not_ready_suppresses_signals(self) -> None:
         """Test that StrategyRunner suppresses all signals when the kill switch is not ready."""
-        metric = NightwatchMetrics()
-        strategy = AlwaysSignalStrategy()
-        buffer = TickBuffer(max_ticks_per_symbol=30)
-        kill_switch = KillSwitch(ready=False)
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, kill_switch=kill_switch)
+        kill_switch = KillSwitch(ready=False, metrics=self.metric)
+        runner = StrategyRunner(strategy=self.momentum_strategy, buffer=self.buffer, metric=self.metric, kill_switch=kill_switch)
 
         tick = make_tick()
         signal = runner.on_market_tick(tick)
         self.assertIsNone(signal)
 
-        suppressed = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch_not_ready") or 0.0
+        suppressed = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch_not_ready") or 0.0
         self.assertEqual(suppressed, 1.0)
 
     def test_mark_ready_allows_signals(self) -> None:
         """Test that after mark_ready(), signals flow normally."""
-        metric = NightwatchMetrics()
-        strategy = AlwaysSignalStrategy()
-        buffer = TickBuffer(max_ticks_per_symbol=30)
-        risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
-        kill_switch = KillSwitch(ready=False)
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
+        kill_switch = KillSwitch(ready=False, metrics=self.metric)
+        runner = StrategyRunner(strategy=self.always_strategy, buffer=self.buffer, metric=self.metric, kill_switch=kill_switch)
 
         tick1 = make_tick()
         self.assertIsNone(runner.on_market_tick(tick1))
@@ -158,18 +146,15 @@ class TestKillSwitch(unittest.TestCase):
         self.assertTrue(kill_switch.ready)
 
         tick2 = make_tick()
-        runner.on_market_tick(tick2)
+        runner.on_market_tick(tick2)  # first tick after buffer clear — suppressed
         tick3 = make_tick()
         signal = runner.on_market_tick(tick3)
         self.assertIsNotNone(signal)
 
     def test_not_ready_with_kill_true_restores_killed_state(self) -> None:
         """Test that applying a kill event while not-ready restores killed state, then marking ready keeps it killed."""
-        metric = NightwatchMetrics()
-        strategy = AlwaysSignalStrategy()
-        buffer = TickBuffer(max_ticks_per_symbol=30)
-        kill_switch = KillSwitch(ready=False)
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, kill_switch=kill_switch)
+        kill_switch = KillSwitch(ready=False, metrics=self.metric)
+        runner = StrategyRunner(strategy=self.momentum_strategy, buffer=self.buffer, metric=self.metric, kill_switch=kill_switch)
 
         kill_event = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Restored from backlog")
         kill_switch.apply(kill_event)
@@ -181,31 +166,37 @@ class TestKillSwitch(unittest.TestCase):
         tick = make_tick()
         signal = runner.on_market_tick(tick)
         self.assertIsNone(signal)
-        suppressed = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
+        suppressed = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch") or 0.0
         self.assertGreater(suppressed, 0.0)
 
     def test_kill_switch_off_then_on_then_off(self) -> None:
         """Test that toggling the kill switch off, then on, then off again works as expected and block/allows signal on each state."""
-        metric = NightwatchMetrics()
-        strategy = AlwaysSignalStrategy()
-        buffer = TickBuffer(max_ticks_per_symbol=30)
-        risk_engine = RiskEngine(rules=[MaxSignalPerMinuteRule(max_signals_per_min=1000)])
-        kill_switch = KillSwitch()
-        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
+        kill_switch = KillSwitch(ready=False, metrics=self.metric)
+        runner = StrategyRunner(strategy=self.always_strategy, buffer=self.buffer, metric=self.metric, kill_switch=kill_switch)
 
         event_off = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Kill switch off")
         kill_switch.apply(event_off)
         self.assertFalse(kill_switch.trading_enabled)
+        kill_switch.mark_ready()
+
+        tick_off_1 = make_tick()
+        self.assertIsNone(runner.on_market_tick(tick_off_1))
 
         event_on = BotControlEvent(kill=False, timestamp=datetime.now(timezone.utc), reason="Kill switch on")
         kill_switch.apply(event_on)
         self.assertTrue(kill_switch.trading_enabled)
 
-        kill_switch.apply(event_off)
+        tick_on = make_tick()
+        self.assertIsNone(runner.on_market_tick(tick_on))
+        tick_on_2 = make_tick()
+        self.assertIsNotNone(runner.on_market_tick(tick_on_2))
+
+        event_off_again = BotControlEvent(kill=True, timestamp=datetime.now(timezone.utc), reason="Kill switch off")
+        kill_switch.apply(event_off_again)
         self.assertFalse(kill_switch.trading_enabled)
 
-        tick = make_tick()
-        signal = runner.on_market_tick(tick)
-        self.assertIsNone(signal)
-        suppressed = metric.get_counter_value(metric.signals_suppressed_total, reason="kill_switch") or 0.0
-        self.assertGreater(suppressed, 0.0)
+        tick_off_2 = make_tick()
+        self.assertIsNone(runner.on_market_tick(tick_off_2))
+
+        suppressed = self.metric.get_counter_value(self.metric.signals_suppressed_total, reason="kill_switch") or 0.0
+        self.assertEqual(suppressed, 2.0)

--- a/tests/Nightwatch/test_rules.py
+++ b/tests/Nightwatch/test_rules.py
@@ -180,3 +180,19 @@ class TestRules(unittest.TestCase):
         self.assertIsNone(rule.evaluate(signal2))
         rule.confirm(signal2)
         self.assertIsNone(rule.evaluate(signal3))
+
+    def test_cleanup_max_signal_per_minute_uses_business_time(self) -> None:
+        """Test that MaxSignalPerMinuteRule cleanup logic uses the signal timestamp, not current time."""
+        rule = MaxSignalPerMinuteRule(max_signals_per_min=1)
+
+        signal1 = make_signal(timestamp=self.signal.timestamp, symbol="AAPL", strategy="TestStrategy")
+        signal2 = make_signal(timestamp=self.signal.timestamp + timedelta(seconds=30), symbol="AAPL", strategy="TestStrategy")
+        signal3 = make_signal(timestamp=self.signal.timestamp + timedelta(seconds=61), symbol="AAPL", strategy="TestStrategy")
+
+        self.assertIsNone(rule.evaluate(signal1))
+        rule.confirm(signal1)
+
+        self.assertIsNotNone(rule.evaluate(signal2))
+        self.assertFalse(rule.evaluate(signal2).allowed)
+
+        self.assertIsNone(rule.evaluate(signal3))

--- a/tests/Nightwatch/test_rules.py
+++ b/tests/Nightwatch/test_rules.py
@@ -192,7 +192,8 @@ class TestRules(unittest.TestCase):
         self.assertIsNone(rule.evaluate(signal1))
         rule.confirm(signal1)
 
-        self.assertIsNotNone(rule.evaluate(signal2))
-        self.assertFalse(rule.evaluate(signal2).allowed)
+        decision2 = rule.evaluate(signal2)
+        self.assertIsNotNone(decision2)
+        self.assertFalse(decision2.allowed)
 
         self.assertIsNone(rule.evaluate(signal3))

--- a/tests/Nightwatch/test_strategy_runner.py
+++ b/tests/Nightwatch/test_strategy_runner.py
@@ -5,7 +5,9 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
+from Nightwatch.kill_switch import KillSwitch
 from Nightwatch.metrics import NightwatchMetrics
+from Nightwatch.models.bot_control_event import BotControlEvent
 from Nightwatch.models.tick_buffer import TickBuffer
 from Nightwatch.risk_engine import RiskEngine
 from Nightwatch.rules.cooldown_rule import CooldownRule
@@ -274,3 +276,58 @@ class TestStrategyRunner(unittest.TestCase):
 
         suppressed = metric.get_counter_value(metric.signals_suppressed_total, reason="MinTradeStrengthRule") or 0.0
         self.assertEqual(suppressed, 0.0)
+
+    def test_given_btc_kill_resume_then_eth_buffer_is_cleared(self) -> None:
+        """When a kill command is received for one symbol, the buffer for a different symbol should also be cleared to prevent contamination."""
+        metric = NightwatchMetrics()
+        strategy = MomentumBurstStrategy(threshold_pct=10, metric=metric)
+        buffer = TickBuffer(max_ticks_per_symbol=30)
+        risk_engine = RiskEngine(rules=[MinTradeStrengthRule(min_strength=1.0)])
+        kill_switch = KillSwitch()
+        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
+
+        btc_ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
+        )
+        eth_ticks = make_tick_sequence(
+            prices=[Decimal("10"), Decimal("10.5"), Decimal("11")], start=self.start_time, interval_sec=5.0, symbol="ETH/USD"
+        )
+
+        feed_ticks(runner, btc_ticks)
+        feed_ticks(runner, eth_ticks)
+
+        kill_switch.apply(BotControlEvent(kill=True, reason="test", timestamp=self.start_time))
+        runner.on_market_tick(btc_ticks[-1])  # suppressed; sets _was_killed = True
+        kill_switch.apply(BotControlEvent(kill=False, reason="test", timestamp=self.start_time))
+
+        signal_eth = feed_ticks(runner, eth_ticks)
+        self.assertIsNotNone(signal_eth)
+
+    def test_given_btc_kill_resume_log_mentions_all_symbols(self) -> None:
+        """When a kill command is received for one symbol, the log should mention all symbols whose buffers were cleared."""
+        metric = NightwatchMetrics()
+        strategy = MomentumBurstStrategy(threshold_pct=10, metric=metric)
+        buffer = TickBuffer(max_ticks_per_symbol=30)
+        risk_engine = RiskEngine(rules=[MinTradeStrengthRule(min_strength=1.0)])
+        kill_switch = KillSwitch()
+        runner = StrategyRunner(strategy=strategy, buffer=buffer, metric=metric, risk_engine=risk_engine, kill_switch=kill_switch)
+
+        btc_ticks = make_tick_sequence(
+            prices=[Decimal("100"), Decimal("105"), Decimal("115")], start=self.start_time, interval_sec=5.0, symbol="BTC/USD"
+        )
+        eth_ticks = make_tick_sequence(
+            prices=[Decimal("10"), Decimal("10.5"), Decimal("11")], start=self.start_time, interval_sec=5.0, symbol="ETH/USD"
+        )
+
+        feed_ticks(runner, btc_ticks)
+        feed_ticks(runner, eth_ticks)
+
+        kill_switch.apply(BotControlEvent(kill=True, reason="test", timestamp=self.start_time))
+        runner.on_market_tick(btc_ticks[-1])  # suppressed; sets _was_killed = True
+        kill_switch.apply(BotControlEvent(kill=False, reason="test", timestamp=self.start_time))
+
+        with self.assertLogs("Nightwatch.strategy_runner", level="INFO") as log:
+            runner.on_market_tick(eth_ticks[0])  # first tick after resume triggers buffer clear log
+
+        log_output = "\n".join(log.output)
+        self.assertIn("Buffers cleared for symbols: BTC/USD, ETH/USD", log_output)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the control event subscriber, strategy runner, and their associated tests. The changes focus on making callback handling more robust, improving buffer management after kill switch events, and enhancing test reliability and clarity. Additionally, the test code is refactored to reduce duplication and improve maintainability.

**Control Event Subscriber improvements:**

- The `subscribe` method in `ControlEventSubscriber` now requires a callback and raises a `ValueError` if none is provided, ensuring that message handling is always explicit and preventing silent failures. The internal logic is updated to reflect this requirement. [[1]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R43-R51) [[2]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4L64-R70) [[3]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4L95) [[4]](diffhunk://#diff-5d0116a327b30a4bb5e29ad038211ce23e525364b0ce2be5d89e4f5cbb68d540L201-R234)
- When draining the JetStream backlog, the code now logs the operation and uses a unique durable name for each drain operation, improving observability and avoiding consumer name collisions.

**Strategy Runner enhancements:**

- Buffer clearing and resumption after a kill switch event are now handled by a dedicated `_handle_resume` method, which logs cleared symbols and ensures the buffer is properly reset before processing new ticks. [[1]](diffhunk://#diff-e6b82a06d3753ccca8faeca36049b5c4dc3e926937ee3f53963af08d6c63266eL46-L50) [[2]](diffhunk://#diff-e6b82a06d3753ccca8faeca36049b5c4dc3e926937ee3f53963af08d6c63266eR113-R120)

**Bug fixes and test improvements:**

- Tests for the control event subscriber are updated to require explicit callbacks, and a default no-op callback is provided for cases where event inspection isn't needed. Tests now verify that omitting a callback raises an error. [[1]](diffhunk://#diff-5d0116a327b30a4bb5e29ad038211ce23e525364b0ce2be5d89e4f5cbb68d540R76-R79) [[2]](diffhunk://#diff-5d0116a327b30a4bb5e29ad038211ce23e525364b0ce2be5d89e4f5cbb68d540L85-R90) [[3]](diffhunk://#diff-5d0116a327b30a4bb5e29ad038211ce23e525364b0ce2be5d89e4f5cbb68d540L149-R157) [[4]](diffhunk://#diff-5d0116a327b30a4bb5e29ad038211ce23e525364b0ce2be5d89e4f5cbb68d540L201-R234)
- The `TestKillSwitch` test class is refactored to use a `setUp` method for shared test data, reducing duplication and improving clarity. All tests now use these shared fixtures. [[1]](diffhunk://#diff-791068dd9643867fbdc5c7dfceeb600bbd057a02c37bb6d8dd740441b88c42c2R23-R69) [[2]](diffhunk://#diff-791068dd9643867fbdc5c7dfceeb600bbd057a02c37bb6d8dd740441b88c42c2L78-R115) [[3]](diffhunk://#diff-791068dd9643867fbdc5c7dfceeb600bbd057a02c37bb6d8dd740441b88c42c2L125-R140) [[4]](diffhunk://#diff-791068dd9643867fbdc5c7dfceeb600bbd057a02c37bb6d8dd740441b88c42c2L161-R157)

**Other code quality improvements:**

- The logic for cleaning up the last-seen dictionary in `MaxSignalPerMinuteRule` is simplified for clarity and correctness.

**Configuration and defaults:**

- The default deliver policy for JetStream consumers is now set via a private module constant, ensuring consistency across the codebase. [[1]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4L24-R25) [[2]](diffhunk://#diff-d49ce5c43cf404dd05bef2e8ff21b3290c1127022560893952d1e2cea87291e4R161-R177)

These changes collectively improve the reliability, maintainability, and clarity of both the main code and its tests.