### PR TITLE
43 411 define order and fill models internal domain objects

### DIFF
--- a/src/Nightwatch/models/fill.py
+++ b/src/Nightwatch/models/fill.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from Nightwatch.models.signal import Side
 
@@ -20,6 +20,8 @@ class Fill(BaseModel):
     price: Decimal = Field(gt=0)
     fee: Decimal = Field(ge=0)
     ts: datetime
+
+    model_config = ConfigDict(str_max_length=255)
 
     @field_validator("symbol")
     @classmethod

--- a/src/Nightwatch/models/fill.py
+++ b/src/Nightwatch/models/fill.py
@@ -1,0 +1,38 @@
+"""Define the Fill model for representing market fills."""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from pydantic import BaseModel, Field, field_validator
+
+from Nightwatch.models.signal import Side
+
+
+class Fill(BaseModel):
+    """Model to represent a market fill."""
+
+    fill_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    side: Side
+    symbol: str = Field(min_length=1)
+    order_id: uuid.UUID
+    qty: Decimal = Field(gt=0)
+    price: Decimal = Field(gt=0)
+    fee: Decimal = Field(ge=0)
+    ts: datetime
+
+    @field_validator("symbol")
+    @classmethod
+    def symbol_not_blank(cls, v: str) -> str:
+        """Ensure that the symbol is not blank or just whitespace."""
+        if not v.strip():
+            raise ValueError("symbol must not be blank")
+        return v
+
+    @field_validator("ts")
+    @classmethod
+    def ts_must_be_timezone_aware(cls, v: datetime) -> datetime:
+        """Require timezone-aware ts and normalize them to UTC."""
+        if v.tzinfo is None or v.utcoffset() is None:
+            raise ValueError("ts must be timezone-aware")
+        return v.astimezone(timezone.utc)

--- a/src/Nightwatch/models/order.py
+++ b/src/Nightwatch/models/order.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from Nightwatch.models.signal import Side
 
@@ -27,6 +27,8 @@ class Order(BaseModel):
     qty: Decimal = Field(gt=0)
     status: Status
     created_at: datetime
+
+    model_config = ConfigDict(str_max_length=255)
 
     @field_validator("symbol")
     @classmethod

--- a/src/Nightwatch/models/order.py
+++ b/src/Nightwatch/models/order.py
@@ -1,0 +1,45 @@
+"""Define the Order model for representing market orders."""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+
+from pydantic import BaseModel, Field, field_validator
+
+from Nightwatch.models.signal import Side
+
+
+class Status(str, Enum):
+    """Enum to represent the status of a market order."""
+
+    NEW = "NEW"
+    FILLED = "FILLED"
+
+
+class Order(BaseModel):
+    """Model to represent a market order."""
+
+    order_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    side: Side
+    symbol: str = Field(min_length=1)
+    signal_id: uuid.UUID
+    qty: Decimal = Field(gt=0)
+    status: Status
+    created_at: datetime
+
+    @field_validator("symbol")
+    @classmethod
+    def symbol_not_blank(cls, v: str) -> str:
+        """Ensure that the symbol is not blank or just whitespace."""
+        if not v.strip():
+            raise ValueError("symbol must not be blank")
+        return v
+
+    @field_validator("created_at")
+    @classmethod
+    def created_at_must_be_timezone_aware(cls, v: datetime) -> datetime:
+        """Require timezone-aware created_at and normalize them to UTC."""
+        if v.tzinfo is None or v.utcoffset() is None:
+            raise ValueError("created_at must be timezone-aware")
+        return v.astimezone(timezone.utc)

--- a/tests/Nightwatch/test_fill.py
+++ b/tests/Nightwatch/test_fill.py
@@ -33,14 +33,14 @@ class TestFill(unittest.TestCase):
         self.assertEqual(self.fill.price, Decimal("50000.0"))
         self.assertEqual(self.fill.fee, Decimal("0.0"))
 
-    def test_price_non_negative(self) -> None:
+    def test_price_strictly_positive(self) -> None:
         """Test that the 'price' attribute must be strictly positive (> 0)."""
         with self.assertRaises(ValueError):
             make_fill(price=Decimal("0.0"))
         with self.assertRaises(ValueError):
             make_fill(price=Decimal("-1.0"))
 
-    def test_qty_non_negative(self) -> None:
+    def test_qty_strictly_positive(self) -> None:
         """Test that the 'qty' attribute must be strictly positive (> 0)."""
         with self.assertRaises(ValueError):
             make_fill(qty=Decimal("0.0"))

--- a/tests/Nightwatch/test_fill.py
+++ b/tests/Nightwatch/test_fill.py
@@ -1,0 +1,85 @@
+"""Unit tests for the Fill model in the Nightwatch application."""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from Nightwatch.models.fill import Fill
+from Nightwatch.models.signal import Side
+from tests.fixtures.fill_factory import make_fill
+
+
+class TestFill(unittest.TestCase):
+    """Unit tests for the Fill model."""
+
+    def setUp(self) -> None:
+        """Set up any necessary data for the tests."""
+        self.fill = make_fill(
+            symbol="BTCUSD",
+            side=Side.BUY,
+            qty=Decimal("1.0"),
+            price=Decimal("50000.0"),
+            fee=Decimal("0.0"),
+        )
+
+    def test_fill_fields(self) -> None:
+        """Test that a Fill can be created with the correct attributes."""
+        self.assertIsNotNone(self.fill.fill_id)
+        self.assertIsNotNone(self.fill.order_id)
+        self.assertIsNotNone(self.fill.ts)
+        self.assertEqual(self.fill.symbol, "BTCUSD")
+        self.assertEqual(self.fill.side.value, "BUY")
+        self.assertEqual(self.fill.qty, Decimal("1.0"))
+        self.assertEqual(self.fill.price, Decimal("50000.0"))
+        self.assertEqual(self.fill.fee, Decimal("0.0"))
+
+    def test_price_non_negative(self) -> None:
+        """Test that the 'price' attribute must be strictly positive (> 0)."""
+        with self.assertRaises(ValueError):
+            make_fill(price=Decimal("0.0"))
+        with self.assertRaises(ValueError):
+            make_fill(price=Decimal("-1.0"))
+
+    def test_qty_non_negative(self) -> None:
+        """Test that the 'qty' attribute must be strictly positive (> 0)."""
+        with self.assertRaises(ValueError):
+            make_fill(qty=Decimal("0.0"))
+        with self.assertRaises(ValueError):
+            make_fill(qty=Decimal("-1.0"))
+
+    def test_fee_non_negative(self) -> None:
+        """Test that the 'fee' attribute must be non-negative (>= 0)."""
+        with self.assertRaises(ValueError):
+            make_fill(fee=Decimal("-1.0"))
+
+    def test_uid_uniqueness(self) -> None:
+        """Test that each Fill instance has a unique UUID."""
+        fill2 = make_fill()
+        self.assertNotEqual(self.fill.fill_id, fill2.fill_id)
+
+    def test_empty_or_blank_symbol_raises(self) -> None:
+        """Test that an empty or blank symbol raises a validation error."""
+        with self.assertRaises(ValueError):
+            make_fill(symbol="")
+        with self.assertRaises(ValueError):
+            make_fill(symbol="   ")
+
+    def test_missing_fields(self) -> None:
+        """Test that missing required fields raise a validation error."""
+        with self.assertRaises(ValueError):
+            Fill(  # type: ignore[call-arg]
+                ts=datetime.now(timezone.utc),
+                side=Side.BUY,
+            )
+
+    def test_naive_ts_raises(self) -> None:
+        """Test that timezone-naive ts timestamps are rejected."""
+        with self.assertRaises(ValueError):
+            make_fill(ts=datetime(2026, 1, 1, 12, 0, 0))
+
+    def test_ts_is_normalized_to_utc(self) -> None:
+        """Test that timezone-aware ts timestamps are normalized to UTC."""
+        local_tz = timezone(timedelta(hours=2))
+        fill = make_fill(ts=datetime(2026, 1, 1, 12, 0, 0, tzinfo=local_tz))
+        self.assertEqual(fill.ts.tzinfo, timezone.utc)
+        self.assertEqual(fill.ts, datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc))

--- a/tests/Nightwatch/test_order.py
+++ b/tests/Nightwatch/test_order.py
@@ -1,0 +1,76 @@
+"""Unit tests for the Order model in the Nightwatch application."""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from Nightwatch.models.order import Order, Status
+from Nightwatch.models.signal import Side
+from tests.fixtures.order_factory import make_order
+
+
+class TestOrder(unittest.TestCase):
+    """Unit tests for the Order model."""
+
+    def setUp(self) -> None:
+        """Set up any necessary data for the tests."""
+        self.order = make_order(
+            symbol="BTCUSD",
+            side=Side.BUY,
+            qty=Decimal("1.0"),
+            status=Status.NEW,
+        )
+
+    def test_order_fields(self) -> None:
+        """Test that an Order can be created with the correct attributes."""
+        self.assertIsNotNone(self.order.order_id)
+        self.assertIsNotNone(self.order.signal_id)
+        self.assertIsNotNone(self.order.created_at)
+        self.assertEqual(self.order.symbol, "BTCUSD")
+        self.assertEqual(self.order.side.value, "BUY")
+        self.assertEqual(self.order.qty, Decimal("1.0"))
+        self.assertEqual(self.order.status, Status.NEW)
+
+    def test_status_only_accepts_valid_values(self) -> None:
+        """Test that the 'status' attribute only accepts valid Status values."""
+        with self.assertRaises(AttributeError):
+            make_order(status=Status.ERROR)  # type: ignore[attr-defined]
+
+    def test_qty_non_negative(self) -> None:
+        """Test that the 'qty' attribute must be strictly positive (> 0)."""
+        with self.assertRaises(ValueError):
+            make_order(qty=Decimal("0.0"))
+        with self.assertRaises(ValueError):
+            make_order(qty=Decimal("-1.0"))
+
+    def test_uid_uniqueness(self) -> None:
+        """Test that each Order instance has a unique UUID."""
+        order2 = make_order()
+        self.assertNotEqual(self.order.order_id, order2.order_id)
+
+    def test_empty_or_blank_symbol_raises(self) -> None:
+        """Test that an empty or blank symbol raises a validation error."""
+        with self.assertRaises(ValueError):
+            make_order(symbol="")
+        with self.assertRaises(ValueError):
+            make_order(symbol="   ")
+
+    def test_missing_fields(self) -> None:
+        """Test that missing required fields raise a validation error."""
+        with self.assertRaises(ValueError):
+            Order(  # type: ignore[call-arg]
+                created_at=datetime.now(timezone.utc),
+                side=Side.BUY,
+            )
+
+    def test_naive_created_at_raises(self) -> None:
+        """Test that timezone-naive created_at timestamps are rejected."""
+        with self.assertRaises(ValueError):
+            make_order(created_at=datetime(2026, 1, 1, 12, 0, 0))
+
+    def test_created_at_is_normalized_to_utc(self) -> None:
+        """Test that timezone-aware created_at timestamps are normalized to UTC."""
+        local_tz = timezone(timedelta(hours=2))
+        order = make_order(created_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=local_tz))
+        self.assertEqual(order.created_at.tzinfo, timezone.utc)
+        self.assertEqual(order.created_at, datetime(2026, 1, 1, 10, 0, 0, tzinfo=timezone.utc))

--- a/tests/Nightwatch/test_order.py
+++ b/tests/Nightwatch/test_order.py
@@ -4,6 +4,8 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
+from pydantic import ValidationError
+
 from Nightwatch.models.order import Order, Status
 from Nightwatch.models.signal import Side
 from tests.fixtures.order_factory import make_order
@@ -33,10 +35,10 @@ class TestOrder(unittest.TestCase):
 
     def test_status_only_accepts_valid_values(self) -> None:
         """Test that the 'status' attribute only accepts valid Status values."""
-        with self.assertRaises(AttributeError):
-            make_order(status=Status.ERROR)  # type: ignore[attr-defined]
+        with self.assertRaises(ValidationError):
+            make_order(status="ERROR")  # type: ignore[arg-type]
 
-    def test_qty_non_negative(self) -> None:
+    def test_qty_strictly_positive(self) -> None:
         """Test that the 'qty' attribute must be strictly positive (> 0)."""
         with self.assertRaises(ValueError):
             make_order(qty=Decimal("0.0"))

--- a/tests/fixtures/fill_factory.py
+++ b/tests/fixtures/fill_factory.py
@@ -1,0 +1,31 @@
+"""Factory functions to create test instances of the Fill model."""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from Nightwatch.models.fill import Fill
+from Nightwatch.models.signal import Side
+
+
+def make_fill(
+    symbol: str = "BTC/USD",
+    side: Side = Side.BUY,
+    order_id: uuid.UUID = uuid.uuid4(),
+    qty: Decimal = Decimal("1.0"),
+    price: Decimal = Decimal("50000.0"),
+    fee: Decimal = Decimal("0.0"),
+    **kwargs: Any,
+) -> Fill:
+    """Helper function to create a Fill with default values for testing."""
+    return Fill(
+        symbol=symbol,
+        side=side,
+        order_id=order_id,
+        qty=qty,
+        price=price,
+        fee=fee,
+        ts=kwargs.pop("ts", datetime.now(timezone.utc)),
+        **kwargs,
+    )

--- a/tests/fixtures/fill_factory.py
+++ b/tests/fixtures/fill_factory.py
@@ -12,13 +12,15 @@ from Nightwatch.models.signal import Side
 def make_fill(
     symbol: str = "BTC/USD",
     side: Side = Side.BUY,
-    order_id: uuid.UUID = uuid.uuid4(),
+    order_id: uuid.UUID | None = None,
     qty: Decimal = Decimal("1.0"),
     price: Decimal = Decimal("50000.0"),
     fee: Decimal = Decimal("0.0"),
     **kwargs: Any,
 ) -> Fill:
     """Helper function to create a Fill with default values for testing."""
+    if order_id is None:
+        order_id = uuid.uuid4()
     return Fill(
         symbol=symbol,
         side=side,

--- a/tests/fixtures/order_factory.py
+++ b/tests/fixtures/order_factory.py
@@ -12,12 +12,14 @@ from Nightwatch.models.signal import Side
 def make_order(
     symbol: str = "BTC/USD",
     side: Side = Side.BUY,
-    signal_id: uuid.UUID = uuid.uuid4(),
+    signal_id: uuid.UUID | None = None,
     qty: Decimal = Decimal("1.0"),
     status: Status = Status.NEW,
     **kwargs: Any,
 ) -> Order:
     """Helper function to create an Order with default values for testing."""
+    if signal_id is None:
+        signal_id = uuid.uuid4()
     return Order(
         symbol=symbol,
         side=side,

--- a/tests/fixtures/order_factory.py
+++ b/tests/fixtures/order_factory.py
@@ -1,0 +1,29 @@
+"""Factory functions to create test instances of the Order model."""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from Nightwatch.models.order import Order, Status
+from Nightwatch.models.signal import Side
+
+
+def make_order(
+    symbol: str = "BTC/USD",
+    side: Side = Side.BUY,
+    signal_id: uuid.UUID = uuid.uuid4(),
+    qty: Decimal = Decimal("1.0"),
+    status: Status = Status.NEW,
+    **kwargs: Any,
+) -> Order:
+    """Helper function to create an Order with default values for testing."""
+    return Order(
+        symbol=symbol,
+        side=side,
+        signal_id=signal_id,
+        qty=qty,
+        status=status,
+        created_at=kwargs.pop("created_at", datetime.now(timezone.utc)),
+        **kwargs,
+    )


### PR DESCRIPTION
This pull request introduces two new Pydantic models, `Order` and `Fill`, to represent market orders and fills in the Nightwatch application. It also adds comprehensive unit tests for both models and provides factory functions to simplify test instance creation. The changes ensure strict validation of model fields, including UUID uniqueness, positive numeric values, and timezone-aware timestamps normalized to UTC.

**New Models and Validation:**

* Added `Order` model in `order.py` with fields for order attributes, strict value validation (e.g., positive quantity, non-blank symbol), and timezone-aware timestamps normalized to UTC. Introduced a `Status` enum for order status.
* Added `Fill` model in `fill.py` with fields for fill attributes, strict value validation (e.g., positive quantity and price, non-negative fee, non-blank symbol), and timezone-aware timestamps normalized to UTC.

**Testing Enhancements:**

* Added `test_order.py` and `test_fill.py` with unit tests covering field validation, UUID uniqueness, enum constraints, and timestamp normalization for both models. [[1]](diffhunk://#diff-f07760f86fcebc209fb3536609365b12c619bad5a7be3a2cc3068e90abef2a2eR1-R76) [[2]](diffhunk://#diff-1307f2de2b41d6d1fc2f2cc48cc6e89154f0aedcfb4f25cb5171efd866d99f69R1-R85)
* Added factory functions `make_order` and `make_fill` in `order_factory.py` and `fill_factory.py` to streamline test instance creation for the models. [[1]](diffhunk://#diff-8228d2e668ac8cf0ea4ffe399099b0ced95cad967c57ac876ff8b819599b20e4R1-R29) [[2]](diffhunk://#diff-b415c5062e585810be11854889659f280dbfbe5675720058e672d562bb7df842R1-R31)