### PR TITLE
feat: implement order factory and portfolio models with associated unit tests

### DIFF
--- a/src/Nightwatch/models/order_factory.py
+++ b/src/Nightwatch/models/order_factory.py
@@ -49,12 +49,15 @@ def create_order_from_signal(
         was received but no position is currently held for the symbol.
 
     Raises:
-        ValueError: If no last price is known for ``signal.symbol`` and a
-            quantity therefore cannot be computed.
+        ValueError: If no last price is known for ``signal.symbol`` or the
+            last price is not positive, and a quantity therefore cannot be
+            computed safely.
     """
     last_price = portfolio.last_price(signal.symbol)
     if last_price is None:
         raise ValueError(f"Cannot size order for {signal.symbol}: no last price available")
+    if last_price <= 0:
+        raise ValueError(f"Cannot size order for {signal.symbol}: last price must be positive, got {last_price}")
 
     if signal.side is Side.BUY:
         qty = config.order_notional / last_price

--- a/src/Nightwatch/models/order_factory.py
+++ b/src/Nightwatch/models/order_factory.py
@@ -50,16 +50,15 @@ def create_order_from_signal(
 
     Raises:
         ValueError: If no last price is known for ``signal.symbol`` or the
-            last price is not positive, and a quantity therefore cannot be
+            last price is not positive for a BUY signal, and a quantity therefore cannot be
             computed safely.
     """
     last_price = portfolio.last_price(signal.symbol)
     if last_price is None:
         raise ValueError(f"Cannot size order for {signal.symbol}: no last price available")
-    if last_price <= 0:
-        raise ValueError(f"Cannot size order for {signal.symbol}: last price must be positive, got {last_price}")
-
     if signal.side is Side.BUY:
+        if last_price <= 0:
+            raise ValueError(f"Cannot size order for {signal.symbol}: last price must be positive, got {last_price}")
         qty = config.order_notional / last_price
     else:
         qty = portfolio.position_qty(signal.symbol)

--- a/src/Nightwatch/models/order_factory.py
+++ b/src/Nightwatch/models/order_factory.py
@@ -1,0 +1,74 @@
+"""Convert approved trading signals into executable :class:`Order` instances.
+
+This module implements a simple, configurable position-sizing rule (v0):
+
+* For ``BUY`` signals, the order quantity is derived from a fixed quote
+  notional divided by the last known market price.
+* For ``SELL`` signals, the order liquidates the full currently held
+  position for the symbol.
+
+If no last price is available for the symbol, no order can be sized and a
+:class:`ValueError` is raised.
+"""
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from Nightwatch.models.order import Order, Status
+from Nightwatch.models.portfolio import Portfolio
+from Nightwatch.models.signal import Side, Signal
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OrderFactoryConfig(BaseModel):
+    """Configuration for the order factory's sizing rule."""
+
+    order_notional: Decimal = Field(gt=0)
+
+    model_config = ConfigDict(str_max_length=255)
+
+
+def create_order_from_signal(
+    signal: Signal,
+    portfolio: Portfolio,
+    config: OrderFactoryConfig,
+) -> Order | None:
+    """Build an :class:`Order` from an approved signal using the v0 sizing rule.
+
+    Args:
+        signal: The approved trading signal to convert.
+        portfolio: Current portfolio state (positions and last prices).
+        config: Sizing configuration (notional per order).
+
+    Returns:
+        A new :class:`Order` in ``NEW`` status, or ``None`` if a SELL signal
+        was received but no position is currently held for the symbol.
+
+    Raises:
+        ValueError: If no last price is known for ``signal.symbol`` and a
+            quantity therefore cannot be computed.
+    """
+    last_price = portfolio.last_price(signal.symbol)
+    if last_price is None:
+        raise ValueError(f"Cannot size order for {signal.symbol}: no last price available")
+
+    if signal.side is Side.BUY:
+        qty = config.order_notional / last_price
+    else:
+        qty = portfolio.position_qty(signal.symbol)
+        if qty <= 0:
+            LOGGER.info("SELL signal %s for %s ignored: no position held", signal.uid, signal.symbol)
+            return None
+
+    return Order(
+        side=signal.side,
+        symbol=signal.symbol,
+        signal_id=signal.uid,
+        qty=qty,
+        status=Status.NEW,
+        created_at=datetime.now(timezone.utc),
+    )

--- a/src/Nightwatch/models/portfolio.py
+++ b/src/Nightwatch/models/portfolio.py
@@ -1,0 +1,28 @@
+"""Define the Portfolio model used for sizing decisions."""
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Portfolio(BaseModel):
+    """Lightweight, in-memory view of currently held positions and last known prices.
+
+    This is intentionally minimal for v0: it exposes per-symbol position quantities
+    and the last observed market price. Components (e.g. the order factory) can
+    consume this state to make sizing decisions without depending on a full
+    accounting subsystem.
+    """
+
+    positions: dict[str, Decimal] = Field(default_factory=dict)
+    last_prices: dict[str, Decimal] = Field(default_factory=dict)
+
+    model_config = ConfigDict(str_max_length=255)
+
+    def position_qty(self, symbol: str) -> Decimal:
+        """Return the currently held quantity for a symbol, or zero if none is held."""
+        return self.positions.get(symbol, Decimal("0"))
+
+    def last_price(self, symbol: str) -> Decimal | None:
+        """Return the last observed price for a symbol, or ``None`` if unknown."""
+        return self.last_prices.get(symbol)

--- a/tests/Nightwatch/test_order_factory.py
+++ b/tests/Nightwatch/test_order_factory.py
@@ -1,0 +1,110 @@
+"""Unit tests for :mod:`Nightwatch.order_factory`."""
+
+import unittest
+from decimal import Decimal
+
+from Nightwatch.models.order import Status
+from Nightwatch.models.order_factory import OrderFactoryConfig, create_order_from_signal
+from Nightwatch.models.signal import Side
+from tests.fixtures.portfolio_factory import make_portfolio
+from tests.fixtures.signal_factory import make_signal
+
+
+class TestOrderFactoryConfig(unittest.TestCase):
+    """Validation tests for the OrderFactoryConfig model."""
+
+    def test_order_notional_must_be_positive(self) -> None:
+        """Test that order_notional must be a positive Decimal."""
+        with self.assertRaises(ValueError):
+            OrderFactoryConfig(order_notional=Decimal("0"))
+        with self.assertRaises(ValueError):
+            OrderFactoryConfig(order_notional=Decimal("-1"))
+
+
+class TestCreateOrderFromSignalBuy(unittest.TestCase):
+    """Tests for BUY signal handling."""
+
+    def setUp(self) -> None:
+        self.config = OrderFactoryConfig(order_notional=Decimal("100"))
+        self.portfolio = make_portfolio(last_prices={"BTC/USD": Decimal("50000")})
+        self.signal = make_signal(symbol="BTC/USD", side=Side.BUY)
+
+    def test_buy_creates_order_with_computed_qty(self) -> None:
+        """Test that a BUY signal creates an Order with the correct computed quantity."""
+        order = create_order_from_signal(self.signal, self.portfolio, self.config)
+
+        self.assertIsNotNone(order)
+        assert order is not None
+        self.assertEqual(order.side, Side.BUY)
+        self.assertEqual(order.symbol, "BTC/USD")
+        self.assertEqual(order.signal_id, self.signal.uid)
+        self.assertEqual(order.qty, Decimal("100") / Decimal("50000"))
+        self.assertEqual(order.status, Status.NEW)
+        self.assertIsNotNone(order.created_at.tzinfo)
+
+    def test_buy_uses_decimal_division_precision(self) -> None:
+        """Test that a BUY signal uses Decimal division precision."""
+        portfolio = make_portfolio(last_prices={"BTC/USD": Decimal("3")})
+        config = OrderFactoryConfig(order_notional=Decimal("10"))
+
+        order = create_order_from_signal(self.signal, portfolio, config)
+
+        assert order is not None
+        self.assertEqual(order.qty, Decimal("10") / Decimal("3"))
+
+
+class TestCreateOrderFromSignalSell(unittest.TestCase):
+    """Tests for SELL signal handling (v0: sell entire position)."""
+
+    def setUp(self) -> None:
+        self.config = OrderFactoryConfig(order_notional=Decimal("100"))
+        self.signal = make_signal(symbol="BTC/USD", side=Side.SELL)
+
+    def test_sell_creates_order_for_full_position(self) -> None:
+        """Test that a SELL signal creates an Order for the full position."""
+        portfolio = make_portfolio(
+            positions={"BTC/USD": Decimal("0.5")},
+            last_prices={"BTC/USD": Decimal("50000")},
+        )
+
+        order = create_order_from_signal(self.signal, portfolio, self.config)
+
+        assert order is not None
+        self.assertEqual(order.side, Side.SELL)
+        self.assertEqual(order.qty, Decimal("0.5"))
+        self.assertEqual(order.signal_id, self.signal.uid)
+        self.assertEqual(order.status, Status.NEW)
+
+    def test_sell_returns_none_when_no_position_held(self) -> None:
+        """Test that a SELL signal returns None when no position is held."""
+        portfolio = make_portfolio(last_prices={"BTC/USD": Decimal("50000")})
+
+        order = create_order_from_signal(self.signal, portfolio, self.config)
+
+        self.assertIsNone(order)
+
+
+class TestCreateOrderFromSignalNoPrice(unittest.TestCase):
+    """Tests for handling missing market price."""
+
+    def test_buy_without_price_raises(self) -> None:
+        """Test that a BUY signal raises an error when no price is available."""
+        config = OrderFactoryConfig(order_notional=Decimal("100"))
+        portfolio = make_portfolio()
+        signal = make_signal(symbol="BTC/USD", side=Side.BUY)
+
+        with self.assertRaises(ValueError):
+            create_order_from_signal(signal, portfolio, config)
+
+    def test_sell_without_price_raises(self) -> None:
+        """Test that a SELL signal raises an error when no price is available."""
+        config = OrderFactoryConfig(order_notional=Decimal("100"))
+        portfolio = make_portfolio(positions={"BTC/USD": Decimal("0.5")})
+        signal = make_signal(symbol="BTC/USD", side=Side.SELL)
+
+        with self.assertRaises(ValueError):
+            create_order_from_signal(signal, portfolio, config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/Nightwatch/test_order_factory.py
+++ b/tests/Nightwatch/test_order_factory.py
@@ -1,4 +1,4 @@
-"""Unit tests for :mod:`Nightwatch.order_factory`."""
+"""Unit tests for :mod:`Nightwatch.models.order_factory`."""
 
 import unittest
 from decimal import Decimal

--- a/tests/Nightwatch/test_portfolio.py
+++ b/tests/Nightwatch/test_portfolio.py
@@ -1,0 +1,41 @@
+"""Unit tests for the Portfolio model."""
+
+import unittest
+from decimal import Decimal
+
+from Nightwatch.models.portfolio import Portfolio
+from tests.fixtures.portfolio_factory import make_portfolio
+
+
+class TestPortfolio(unittest.TestCase):
+    """Unit tests for the Portfolio model."""
+
+    def test_defaults_to_empty(self) -> None:
+        """Test that a Portfolio can be created with default empty values."""
+        portfolio = Portfolio()
+        self.assertEqual(portfolio.positions, {})
+        self.assertEqual(portfolio.last_prices, {})
+
+    def test_position_qty_returns_zero_when_missing(self) -> None:
+        """Test that position_qty returns 0 when no position is held for the symbol."""
+        portfolio = make_portfolio()
+        self.assertEqual(portfolio.position_qty("BTC/USD"), Decimal("0"))
+
+    def test_position_qty_returns_held_quantity(self) -> None:
+        """Test that position_qty returns the correct quantity for a held position."""
+        portfolio = make_portfolio(positions={"BTC/USD": Decimal("0.5")})
+        self.assertEqual(portfolio.position_qty("BTC/USD"), Decimal("0.5"))
+
+    def test_last_price_returns_none_when_missing(self) -> None:
+        """Test that last_price returns None when no price is known for the symbol."""
+        portfolio = make_portfolio()
+        self.assertIsNone(portfolio.last_price("BTC/USD"))
+
+    def test_last_price_returns_known_price(self) -> None:
+        """Test that last_price returns the correct price for a known symbol."""
+        portfolio = make_portfolio(last_prices={"BTC/USD": Decimal("50000")})
+        self.assertEqual(portfolio.last_price("BTC/USD"), Decimal("50000"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fixtures/portfolio_factory.py
+++ b/tests/fixtures/portfolio_factory.py
@@ -13,7 +13,7 @@ def make_portfolio(
 ) -> Portfolio:
     """Helper function to create a Portfolio with default values for testing."""
     return Portfolio(
-        positions=positions or {},
-        last_prices=last_prices or {},
+        positions={} if positions is None else positions,
+        last_prices={} if last_prices is None else last_prices,
         **kwargs,
     )

--- a/tests/fixtures/portfolio_factory.py
+++ b/tests/fixtures/portfolio_factory.py
@@ -1,0 +1,19 @@
+"""Factory functions to create test instances of the Portfolio model."""
+
+from decimal import Decimal
+from typing import Any
+
+from Nightwatch.models.portfolio import Portfolio
+
+
+def make_portfolio(
+    positions: dict[str, Decimal] | None = None,
+    last_prices: dict[str, Decimal] | None = None,
+    **kwargs: Any,
+) -> Portfolio:
+    """Helper function to create a Portfolio with default values for testing."""
+    return Portfolio(
+        positions=positions or {},
+        last_prices=last_prices or {},
+        **kwargs,
+    )


### PR DESCRIPTION
…it tests
This pull request introduces a new, minimal position sizing and order creation system for trading signals, along with comprehensive unit tests and supporting test fixtures. The main focus is on converting approved trading signals into executable orders using a simple, configurable rule, and on modeling the portfolio state required for these decisions.

**Core functionality:**

* Added `OrderFactoryConfig` and `create_order_from_signal` in `order_factory.py` to convert trading signals into executable orders using a fixed notional sizing rule. Handles both BUY (notional/price) and SELL (full liquidation) signals, with error handling for missing prices.
* Introduced a lightweight `Portfolio` model in `portfolio.py` to track per-symbol positions and last known prices, including helper methods for querying held quantities and prices.

**Testing and fixtures:**

* Added unit tests for the order factory logic, covering both BUY and SELL flows, input validation, and error handling for missing prices in `test_order_factory.py`.
* Added unit tests for the `Portfolio` model, verifying default values and correct behavior of helper methods in `test_portfolio.py`.
* Introduced a `make_portfolio` factory function for creating test portfolio instances with customizable state in `portfolio_factory.py`.